### PR TITLE
Fix incorrect version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@ Notable changes to this project will be documented in this file.
   * Random game option
 * **Pause screen:** show a decent pause screen when menu is open during gameplay ([4c9f3ec](https://github.com/matbo87/snes9x_3ds/commit/4c9f3ecb333eaf23da85e9199bdbbfa3511312dd))
 
-### Bug Fixes
-* **O2DS**: fix crash on O2DS (and probably O3DS as well) when saving SRAM ([#2](https://github.com/matbo87/snes9x_3ds/issues/2)) ([02788b1](https://github.com/matbo87/snes9x_3ds/commit/02788b17d038e30e612dcbf0719ec45a8fc54a43))
-
 ### Code Refactoring
 * **Menu**: reduce redundant code + preserve selected item index per tab ([493c1a2](https://github.com/matbo87/snes9x_3ds/commit/493c1a22b3975c7cb39a55dbd38140e5e3cd2a14), [4d6378a](https://github.com/matbo87/snes9x_3ds/commit/4d6378a507cb77571e4444abb6fbd0df3ff5f555))
 * **Dialogs**: remove unnecessary animations for a snappier appearance ([2bb82c6](https://github.com/matbo87/snes9x_3ds/commit/2bb82c69512a2ef894ee5bb049be13ba567b6e89))
@@ -47,6 +44,8 @@ Notable changes to this project will be documented in this file.
 ### Breaking changes
 * **Folder structure:** All game related files are now in "3ds/snes9x_3ds", similar to RetroArch folder structure
 
+### Bug Fixes
+* **O2DS**: fix crash on O2DS (and probably O3DS as well) when saving SRAM ([#2](https://github.com/matbo87/snes9x_3ds/issues/2)) ([02788b1](https://github.com/matbo87/snes9x_3ds/commit/02788b17d038e30e612dcbf0719ec45a8fc54a43))
 
 ---
 ## Older releases


### PR DESCRIPTION
This was fixed in version 1.50, and 1.51 ironically introduces the bug again, so this PR fixes this mistake in the changelog to prevent further confusion (see #11)