### PR TITLE
Minor Fixes for Blurriness and New Fit Scaling Option

### DIFF
--- a/source/3dsimpl_gpu.cpp
+++ b/source/3dsimpl_gpu.cpp
@@ -360,8 +360,8 @@ void gpu3dsBindTextureSnesTileCacheForHires(GPU_TEXUNIT unit)
 void gpu3dsBindTextureMainScreen(GPU_TEXUNIT unit)
 {
     gpu3dsBindTextureWithParams(snesMainScreenTarget, unit,
-        GPU_TEXTURE_MAG_FILTER(GPU_LINEAR)
-        | GPU_TEXTURE_MIN_FILTER(GPU_LINEAR)
+        GPU_TEXTURE_MAG_FILTER(GPU_NEAREST)
+        | GPU_TEXTURE_MIN_FILTER(GPU_NEAREST)
         | GPU_TEXTURE_WRAP_S(GPU_CLAMP_TO_BORDER)
         | GPU_TEXTURE_WRAP_T(GPU_CLAMP_TO_BORDER));
 }

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -785,6 +785,7 @@ std::vector<SMenuItem> makeOptionsForStretch() {
         AddMenuDialogOption(items, 3, "Cropped 4:3 Fit"s,         "Crop & Stretch to 320x240"s);
         AddMenuDialogOption(items, 4, "Fullscreen"s,              "Stretch to 400x240");
         AddMenuDialogOption(items, 5, "Cropped Fullscreen"s,      "Crop & Stretch to 400x240");
+        AddMenuDialogOption(items, 6, "8:7 Fit"s,                 "Stretch to 272x238"s);
     }
 
     else {
@@ -1152,6 +1153,12 @@ bool settingsUpdateAllSettings(bool updateGameSettings = true)
         settings3DS.StretchWidth = screenSettings.GameScreenWidth;
         settings3DS.StretchHeight = SCREEN_HEIGHT;
         settings3DS.CropPixels = 8;
+    }
+    else if (settings3DS.ScreenStretch == 6) // 8:7 Fit
+    {
+        settings3DS.StretchWidth = 272;
+        settings3DS.StretchHeight = 238;
+        settings3DS.CropPixels = 0;
     } else {
          // No Stretch / Pixel Perfect
         settings3DS.StretchWidth = 256;

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -118,6 +118,7 @@ typedef struct S9xSettings3DS
                                             // 3 - Cropped 4:3 Fit: Crop & Stretch to 320 x 240
                                             // 4 - Fullscreen: Stretch to GameScreenWidth x 240
                                             // 5 - Cropped Fullscreen: Crop & Stretch to GameScreenWidth x 240
+                                            // 6 - 8:7 Fit: Stretch to 272x238, keeping original SNES Aspect Ratio.
 
     EmulatedFramerate ForceFrameRate = EmulatedFramerate::UseRomRegion;
 


### PR DESCRIPTION
Hey!

I have been recently using your port of Snes9x for 3DS and I noticed there were two issues that were bothering me a bit and decided to get my hands dirty to see if they could be fixed. Those were:
- Using any of the Stretch Scaling Options resulted in a blurry end result on screen.
- Original 'No Stretch' scaling option could be too small on the non XL DS models. 4:3 fit or "TV" didn't make much sense to me as we would be loosing the original SNES aspect ratio which results in distorted visuals.

So, I applied two patches to fix the issues. In my own testing I believe they worked great and now the Snes9x experience on my 3DS feels pretty much perfect. Then I decided to do a pull request here in case it is of interest to get these changes merged.

Cheers,
Alanzote.

