### PR TITLE
fix(sound): null-check before dereference in snd3dsInitialize

### DIFF
--- a/source/3dssound.cpp
+++ b/source/3dssound.cpp
@@ -283,9 +283,6 @@ bool snd3dsInitialize()
     // Initialize the sound buffers
     //
     snd3DS.fullBuffers = (short *)linearAlloc(snd3dsSampleRate * 2 * 2);
-	snd3DS.leftBuffer = &snd3DS.fullBuffers[0];
-	snd3DS.rightBuffer = &snd3DS.fullBuffers[snd3dsSampleRate];
-    memset(snd3DS.fullBuffers, 0, snd3dsSampleRate * 2 * 2);
 
     if (!snd3DS.fullBuffers)
     {
@@ -294,6 +291,10 @@ bool snd3dsInitialize()
         snd3dsFinalize();
         return false;
     }
+
+	snd3DS.leftBuffer = &snd3DS.fullBuffers[0];
+	snd3DS.rightBuffer = &snd3DS.fullBuffers[snd3dsSampleRate];
+    memset(snd3DS.fullBuffers, 0, snd3dsSampleRate * 2 * 2);
 
     if (snd3DS.audioType == 1)
     {


### PR DESCRIPTION
## Summary
- Moves `leftBuffer`/`rightBuffer` assignment and `memset` after the null check for `fullBuffers`
- If `linearAlloc` fails, the original code dereferences null for the buffer assignments and memsets, causing a crash

## Test plan
- [ ] Verify audio still works normally after change
- [ ] Verify no crash on memory-constrained systems where `linearAlloc` might fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)