### PR TITLE
fix: isReal3DS memory leak and missing return statements

### DIFF
--- a/source/3dsgpu.cpp
+++ b/source/3dsgpu.cpp
@@ -366,12 +366,11 @@ void gpu3dsFrameEnd(u8 flags)
 
 // may give us false positives, but works at least for citra nightly 1989 (mac)
 bool isReal3DS() {
-    Result ret = 0;
-    OS_VersionBin *nver = new OS_VersionBin[sizeof(OS_VersionBin)];
-    OS_VersionBin *cver = new OS_VersionBin[sizeof(OS_VersionBin)];
+    OS_VersionBin nver = {};
+    OS_VersionBin cver = {};
     static char systemVersionString[128];
-    
-    if (R_FAILED(ret = osGetSystemVersionDataString(nver, cver, systemVersionString, sizeof(systemVersionString)))) {
+
+    if (R_FAILED(osGetSystemVersionDataString(&nver, &cver, systemVersionString, sizeof(systemVersionString)))) {
         return false;
     }
 

--- a/source/3dsimpl.cpp
+++ b/source/3dsimpl.cpp
@@ -1075,12 +1075,12 @@ const char * S9xGetFilenameInc (const char *ex)
 
 bool8 S9xReadMousePosition (int which1_0_to_1, int &x, int &y, uint32 &buttons)
 {
-
+	return FALSE;
 }
 
 bool8 S9xReadSuperScopePosition (int &x, int &y, uint32 &buttons)
 {
-
+	return FALSE;
 }
 
 bool JustifierOffscreen()


### PR DESCRIPTION
## Summary
- **3dsgpu.cpp**: `isReal3DS()` used heap allocation (`new[]`) without `delete`, leaking memory on every call. Changed to stack allocation.
- **3dsimpl.cpp**: `S9xReadMousePosition` and `S9xReadSuperScopePosition` had empty function bodies with no return statement (undefined behavior for `bool8` return type). Added explicit `return FALSE`.

## Test plan
- [ ] Verify `isReal3DS()` still correctly detects real 3DS vs Citra
- [ ] Verify no regression in mouse/superscope input handling (these functions are stubs on 3DS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)