### PR TITLE
Audio: migrate from deprecated CSND to NDSP (Citra/Azahar sound support)

### DIFF
--- a/source/3dsimpl.cpp
+++ b/source/3dsimpl.cpp
@@ -435,8 +435,10 @@ bool impl3dsLoadROM(char *romFilePath)
 //---------------------------------------------------------
 void impl3dsResetConsole()
 {
+	snd3dsDrainMixing();
 	S9xReset();
 	gpu3dsInitializeMode7Vertexes();
+	snd3dsResumeMixing();
 }
 
 // applies the provided cache operation (flush or invalidate) to the correct memory.

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -1250,9 +1250,9 @@ bool emulatorLoadRom()
     snprintf(romFileNameFullPath, sizeof(romFileNameFullPath), "%s%s", file3dsGetCurrentDir(), romFileName);
 
     // Block the audio mixing thread from touching APU/memory state while
-    // Memory.LoadROM tears down and rebuilds SNES9x globals. Without this,
-    // NDSP's mixing thread faults reading half-initialised state on game
-    // switch (data-abort exception).
+    // Memory.LoadROM tears down and rebuilds SNES9x globals AND while
+    // dependent state is rebuilt (settings, slot state, savestate auto-load).
+    // Without this the mixing thread faults reading half-initialised state.
     snd3dsDrainMixing();
 
     // when impl3dsLoadROM fails, our previous game (if any) is also unusable
@@ -1260,9 +1260,8 @@ bool emulatorLoadRom()
     Memory.ROMCRC32 = 0;
     settings3DS.isRomLoaded = impl3dsLoadROM(romFileNameFullPath) && Memory.ROMCRC32;
 
-    snd3dsResumeMixing();
-
     if (!settings3DS.isRomLoaded) {
+        snd3dsResumeMixing();
         return false;
     }
 
@@ -1273,7 +1272,7 @@ bool emulatorLoadRom()
     // update global config
     snprintf(settings3DS.lastSelectedDir, sizeof(settings3DS.lastSelectedDir), "%s", file3dsGetCurrentDir());
     snprintf(settings3DS.lastSelectedFilename, sizeof(settings3DS.lastSelectedFilename), "%s", romFileName);
-    
+
     settings3DS.isDirty = true;
     settings3dsResetGameDefaults();
 
@@ -1282,22 +1281,23 @@ bool emulatorLoadRom()
     cfgFileAvailable[1] = settingsReadWriteFullListByGame(false);
 
     settings3dsUpdate(true);
-    
+
     // check for valid hotkeys if circle pad binding is enabled
     // TODO: clean up
     if ((!settings3DS.UseGlobalButtonMappings && settings3DS.BindCirclePad) ||
         (settings3DS.UseGlobalButtonMappings && settings3DS.GlobalBindCirclePad))
         for (int i = 0; i < HOTKEYS_COUNT; ++i)
             ResetHotkeyIfNecessary(i, true);
-    
+
     // set proper state (radio_state) for every save slot of loaded game
     for (int slot = 1; slot <= SAVESLOTS_MAX; ++slot)
         impl3dsUpdateSlotState(slot, true);
 
     if (settings3DS.AutoSavestate)
         impl3dsLoadStateAuto();
-        
-    return true;   
+
+    snd3dsResumeMixing();
+    return true;
 }
 
 //----------------------------------------------------------------------

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -1249,10 +1249,18 @@ bool emulatorLoadRom()
     char romFileNameFullPath[PATH_MAX];
     snprintf(romFileNameFullPath, sizeof(romFileNameFullPath), "%s%s", file3dsGetCurrentDir(), romFileName);
 
+    // Block the audio mixing thread from touching APU/memory state while
+    // Memory.LoadROM tears down and rebuilds SNES9x globals. Without this,
+    // NDSP's mixing thread faults reading half-initialised state on game
+    // switch (data-abort exception).
+    snd3dsDrainMixing();
+
     // when impl3dsLoadROM fails, our previous game (if any) is also unusable
     // therefore we always set ROMCRC32 to 0
-    Memory.ROMCRC32 = 0; 
+    Memory.ROMCRC32 = 0;
     settings3DS.isRomLoaded = impl3dsLoadROM(romFileNameFullPath) && Memory.ROMCRC32;
+
+    snd3dsResumeMixing();
 
     if (!settings3DS.isRomLoaded) {
         return false;

--- a/source/3dssound.cpp
+++ b/source/3dssound.cpp
@@ -158,6 +158,33 @@ void snd3dsStopPlaying()
 
 
 //---------------------------------------------------------
+// Pause the mixing thread from touching SNES state.
+//
+// Sets generateSilence and sleeps for a couple of mix
+// periods so any in-flight impl3dsGenerateSoundSamples call
+// has finished before the caller starts tearing down ROM /
+// APU / memory state. Without this, the mixing thread reads
+// half-initialised globals during a ROM switch and the
+// emulator crashes with a data-abort exception.
+//---------------------------------------------------------
+void snd3dsDrainMixing()
+{
+    snd3DS.generateSilence = true;
+
+    // Longest possible in-flight work is one wavebuf fill, which at
+    // 256 frames @ 32 kHz is ~8ms. NDSP frame callback is ~5ms.
+    // 30ms wait is ~4 mix iterations — fully drains the pipe.
+    svcSleepThread(30 * 1000000);
+}
+
+
+void snd3dsResumeMixing()
+{
+    snd3DS.generateSilence = false;
+}
+
+
+//---------------------------------------------------------
 // Initialize the NDSP audio pipeline.
 //
 // Returns true on success. On failure (ndspInit fails because

--- a/source/3dssound.cpp
+++ b/source/3dssound.cpp
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 
 #include "snes9x.h"
 #include "spc700.h"
@@ -12,141 +13,99 @@
 #include "3dsimpl.h"
 #include "3dslog.h"
 
-#define LEFT_CHANNEL        10
-#define RIGHT_CHANNEL       11
-
 
 SSND3DS snd3DS;
 
-int debugSoundCounter = 0;
-int csndTicksPerSecond = 268033000LL;           // use this for 32000 Khz
-
-int snd3dsSampleRate = 44100;
-int snd3dsSamplesPerLoop = 735;
+static int snd3dsSampleRate = 32000;
+static int snd3dsSamplesPerLoop = 256;
 
 static u32 old_time_limit = UINT32_MAX;
 
-//---------------------------------------------------------
-// Gets the current playing sample position.
-//
-// The problem is that the existing CSND library
-// is unable to provide the actual playing sample
-// position from the hardware. So we have to compute
-// this manually. 
-//
-// But computing it this way may cause skews in sound
-// generation over time, so the csndTicksPerSecond
-// has to be correct to minimize skewing.
-//---------------------------------------------------------
-u64 snd3dsGetSamplePosition() {
-	u64 delta = (svcGetSystemTick() - snd3DS.startTick);
-	u64 samplePosition = delta * snd3dsSampleRate / csndTicksPerSecond;
+// Staging buffers for the SNES9x mixer — it writes separate L/R streams
+// and we interleave into the NDSP wavebuf. Sized well above the usual
+// 256 samplesPerLoop; snd3dsSetSampleRate caps samplesPerLoop at this.
+#define SND3DS_STAGING_FRAMES_MAX   2048
+static short stagingL[SND3DS_STAGING_FRAMES_MAX];
+static short stagingR[SND3DS_STAGING_FRAMES_MAX];
 
-    snd3DS.samplePosition = samplePosition;
-	return samplePosition;
+
+//---------------------------------------------------------
+// Set the sampling rate + block size.
+//
+// Must be called before snd3dsInitialize().
+//---------------------------------------------------------
+void snd3dsSetSampleRate(int sampleRate, int samplesPerLoop)
+{
+    if (samplesPerLoop > SND3DS_STAGING_FRAMES_MAX)
+        samplesPerLoop = SND3DS_STAGING_FRAMES_MAX;
+
+    snd3dsSampleRate = sampleRate;
+    snd3dsSamplesPerLoop = samplesPerLoop;
 }
 
-int blockCount = 0;
-
 
 //---------------------------------------------------------
-// Mix the samples.
+// Mix one block and hand it off to NDSP.
 //
-// This is usually called from within 3dssound.cpp.
-// It should only be called externall from other 
-// files when running in Citra.
+// Polls the fillBlock wavebuf; when it has been consumed by
+// the DSP (NDSP_WBUF_DONE) or never queued (NDSP_WBUF_FREE),
+// we produce snd3dsSamplesPerLoop frames into it and re-queue.
+// If no buffer is ready we sleep briefly and return — the
+// mixing thread loops immediately.
 //---------------------------------------------------------
 void snd3dsMixSamples()
 {
-    #define MIN_FORWARD_BLOCKS          8
-    #define MAX_FORWARD_BLOCKS          16
+    if (snd3DS.audioType != 2)
+        return;
 
-    bool generateSound = false;
-    if (snd3DS.isPlaying && !snd3DS.generateSilence)
+    ndspWaveBuf *wb = &snd3DS.waveBufs[snd3DS.fillBlock];
+
+    if (wb->status != NDSP_WBUF_DONE && wb->status != NDSP_WBUF_FREE)
+    {
+        // DSP still chewing on this buffer — back off briefly so we
+        // don't spin. NDSP frame tick is ~5ms, a 500us sleep is plenty.
+        svcSleepThread(500000);
+        return;
+    }
+
+    bool generateSound = snd3DS.isPlaying && !snd3DS.generateSilence;
+    short *dst = (short *)wb->data_vaddr;
+    int frames = snd3dsSamplesPerLoop;
+
+    if (generateSound)
     {
         impl3dsGenerateSoundSamples();
-        generateSound = true;
-    }
+        impl3dsOutputSoundSamples(stagingL, stagingR);
 
-    long generateAtSamplePosition = 0;
-    while (true)
+        for (int i = 0; i < frames; i++)
+        {
+            dst[i * 2]     = stagingL[i];
+            dst[i * 2 + 1] = stagingR[i];
+        }
+    }
+    else
     {
-        u64 nowSamplePosition = snd3dsGetSamplePosition();
-        u64 deltaTimeAhead = snd3DS.upToSamplePosition - nowSamplePosition;
-        long blocksAhead = deltaTimeAhead / snd3dsSamplesPerLoop;
-
-        if (blocksAhead < MIN_FORWARD_BLOCKS)
-        {
-            // buffer is about to underrun.
-            //
-            generateAtSamplePosition =
-                ((u64)((nowSamplePosition + snd3dsSamplesPerLoop - 1) / snd3dsSamplesPerLoop)) * snd3dsSamplesPerLoop +
-                MIN_FORWARD_BLOCKS * snd3dsSamplesPerLoop;
-            break;
-        }
-        else if (blocksAhead < MAX_FORWARD_BLOCKS)
-        {
-            // play head is still within acceptable range.
-            // so we place the generated samples at where
-            // we left off previously
-            //
-            generateAtSamplePosition = snd3DS.upToSamplePosition;
-            break;
-        }
-
-        // blocksAhead >= MAX_FORWARD_BLOCKS
-        // although we've already mixed the previous block,
-        // we are too ahead of time, so let's wait for 0.1 millisecs.
-        //
-        // That may help to save some battery.
-        //
-        svcSleepThread(100000);
+        memset(dst, 0, (size_t)frames * 2 * sizeof(short));
     }
 
-    snd3DS.startSamplePosition = generateAtSamplePosition;
-    snd3DS.upToSamplePosition = generateAtSamplePosition + snd3dsSamplesPerLoop;
-    
-    int p = generateAtSamplePosition % snd3dsSampleRate;
+    DSP_FlushDataCache(dst, (u32)(frames * 2 * sizeof(short)));
+    ndspChnWaveBufAdd(0, wb);
 
-    if (snd3DS.audioType==1)
-    {
-        if (generateSound)
-        {
-            impl3dsOutputSoundSamples(&snd3DS.leftBuffer[p], &snd3DS.rightBuffer[p]);
-        }
-        else
-        {
-            for (int i = 0; i < snd3dsSamplesPerLoop; i++)
-            {
-                snd3DS.leftBuffer[p + i] = 0;
-                snd3DS.rightBuffer[p + i] = 0;
-            }
-        }
-    }
-    // Now that we have the samples, we have to copy it back into our buffers
-    // for the 3DS to playback
-    //
-    blockCount++;
-    if (blockCount % MIN_FORWARD_BLOCKS == 0)
-        svcFlushProcessDataCache(CUR_PROCESS_HANDLE, (u32)snd3DS.fullBuffers, snd3dsSampleRate * 2 * 2);
+    snd3DS.fillBlock = (snd3DS.fillBlock + 1) % SND3DS_WAVEBUF_COUNT;
 }
 
 
 //---------------------------------------------------------
-// This function is the entry point to the sound mixing
-// thread.
+// Mixing thread entry point.
+//
+// Runs on both real hardware and emulators. NDSP is emulated
+// by Citra/Azahar (given dspfirm.cdc), so audio now works in
+// either case — no more Citra-gated thread creation.
 //---------------------------------------------------------
-void snd3dsMixingThread(void *p)
+static void snd3dsMixingThread(void *p)
 {
-    snd3DS.upToSamplePosition = snd3dsGetSamplePosition();
-    snd3DS.startSamplePosition = snd3DS.upToSamplePosition;
-    //svcExitThread();
-    //return;
-
     while (!snd3DS.terminateMixingThread)
     {
-        if (!GPU3DS.isReal3DS)
-            svcSleepThread(1000000 * 1);
         snd3dsMixSamples();
     }
     snd3DS.terminateMixingThread = -1;
@@ -155,72 +114,29 @@ void snd3dsMixingThread(void *p)
 
 
 //---------------------------------------------------------
-// Triggers the CSND to play the sound from the
-// buffers.
-//---------------------------------------------------------
-void snd3dsPlaySound(int chn, u32 flags, u32 sampleRate, float vol, float pan, void* data0, void* data1, u32 size)
-{
-	u32 paddr0 = 0, paddr1 = 0;
-
-	int encoding = (flags >> 12) & 3;
-	int loopMode = (flags >> 10) & 3;
-
-	if (!loopMode) flags |= SOUND_ONE_SHOT;
-
-	if (encoding != CSND_ENCODING_PSG)
-	{
-		if (data0) paddr0 = osConvertVirtToPhys(data0);
-		if (data1) paddr1 = osConvertVirtToPhys(data1);
-
-		if (data0 && encoding == CSND_ENCODING_ADPCM)
-		{
-			int adpcmSample = ((s16*)data0)[-2];
-			int adpcmIndex = ((u8*)data0)[-2];
-			CSND_SetAdpcmState(chn, 0, adpcmSample, adpcmIndex);
-		}
-	}
-
-	u32 timer = CSND_TIMER(sampleRate);
-	if (timer < 0x0042) timer = 0x0042;
-	else if (timer > 0xFFFF) timer = 0xFFFF;
-	flags &= ~0xFFFF001F;
-	flags |= SOUND_ENABLE | SOUND_CHANNEL(chn) | (timer << 16);
-
-	u32 volumes = CSND_VOL(vol, pan);
-	CSND_SetChnRegs(flags, paddr0, paddr1, size, volumes, volumes);
-
-	if (loopMode == CSND_LOOPMODE_NORMAL && paddr1 > paddr0)
-	{
-		// Now that the first block is playing, configure the size of the subsequent blocks
-		size -= paddr1 - paddr0;
-		CSND_SetBlock(chn, 1, paddr1, size);
-	}
-    CSND_SetPlayState(chn, 1);
-}
-
-
-//---------------------------------------------------------
 // Start playing the samples.
+//
+// Primes both NDSP wavebufs so the channel has something to
+// play immediately. The mixing thread will keep them fed.
 //---------------------------------------------------------
 void snd3dsStartPlaying()
 {
-    if (!snd3DS.isPlaying)
-    {
-        // CSND
-        // Fix: Copied libctru's csndPlaySound and modified it so that it will
-        // not play immediately upon calling. This seems to solve the left
-        // channel louder than right channel problem.
-        //
-        snd3dsPlaySound(LEFT_CHANNEL, SOUND_REPEAT | SOUND_FORMAT_16BIT, snd3dsSampleRate, 1.0f, -1.0f, (u32*)snd3DS.leftBuffer, (u32*)snd3DS.leftBuffer, snd3dsSampleRate * 2);
-        snd3dsPlaySound(RIGHT_CHANNEL, SOUND_REPEAT | SOUND_FORMAT_16BIT, snd3dsSampleRate, 1.0f, 1.0f, (u32*)snd3DS.rightBuffer, (u32*)snd3DS.rightBuffer, snd3dsSampleRate * 2);
+    if (snd3DS.isPlaying)
+        return;
 
-        // Flush CSND command buffers
-        csndExecCmds(true);
-        snd3DS.startTick = svcGetSystemTick();
-        snd3DS.upToSamplePosition = 0;
-        snd3DS.isPlaying = true;
-        snd3DS.generateSilence = false;
+    if (snd3DS.audioType != 2)
+        return;
+
+    // Mark both wavebufs as free so the first snd3dsMixSamples iterations
+    // fill them in order.
+    for (int i = 0; i < SND3DS_WAVEBUF_COUNT; i++)
+    {
+        snd3DS.waveBufs[i].status = NDSP_WBUF_FREE;
     }
+    snd3DS.fillBlock = 0;
+
+    snd3DS.isPlaying = true;
+    snd3DS.generateSilence = false;
 }
 
 
@@ -229,34 +145,24 @@ void snd3dsStartPlaying()
 //---------------------------------------------------------
 void snd3dsStopPlaying()
 {
-    if (snd3DS.isPlaying)
+    if (!snd3DS.isPlaying)
+        return;
+
+    if (snd3DS.audioType == 2)
     {
-        CSND_SetPlayState(LEFT_CHANNEL, 0);
-        CSND_SetPlayState(RIGHT_CHANNEL, 0);
-
-        // Flush CSND command buffers
-        csndExecCmds(true);
-        snd3DS.isPlaying = false;
+        ndspChnWaveBufClear(0);
     }
+
+    snd3DS.isPlaying = false;
 }
 
 
 //---------------------------------------------------------
-// Set the sampling rate.
+// Initialize the NDSP audio pipeline.
 //
-// This function should be called by the 
-// impl3dsInitialize function. It CANNOT be called
-// after the snd3dsInitialize function is called.
-//---------------------------------------------------------
-void snd3dsSetSampleRate(int sampleRate, int samplesPerLoop)
-{
-    snd3dsSampleRate = sampleRate;
-    snd3dsSamplesPerLoop = samplesPerLoop;
-}
-
-
-//---------------------------------------------------------
-// Initialize the CSND library.
+// Returns true on success. On failure (ndspInit fails because
+// dspfirm.cdc is absent, or service blocked) the app continues
+// silently — audio is not a hard dependency.
 //---------------------------------------------------------
 bool snd3dsInitialize()
 {
@@ -264,137 +170,120 @@ bool snd3dsInitialize()
 
     snd3DS.isPlaying = false;
     snd3DS.audioType = 0;
-    Result ret = csndInit();
-    log3dsWrite("Trying to initialize CSND, ret = %lx", (unsigned long)ret);
 
-	if (!R_FAILED(ret))
+    Result ret = ndspInit();
+    log3dsWrite("ndspInit ret = 0x%lx", (unsigned long)ret);
+    if (R_FAILED(ret))
     {
-        snd3DS.audioType = 1;
-        log3dsWrite("CSND Initialized");
-    }
-    else
-    {
-        log3dsWrite("Unable to initialize 3DS CSND service");
-
+        log3dsWrite("NDSP init failed — continuing without audio");
         return false;
     }
 
-    // Initialize the sound buffers
-    //
-    snd3DS.fullBuffers = (short *)linearAlloc(snd3dsSampleRate * 2 * 2);
+    snd3DS.audioType = 2;
 
-    if (!snd3DS.fullBuffers)
+    // Single linearAlloc covers all wavebufs back-to-back.
+    int framesPerBuffer = snd3dsSamplesPerLoop;
+    int bytesPerBuffer = framesPerBuffer * 2 * sizeof(short); // stereo PCM16
+    int totalBytes = bytesPerBuffer * SND3DS_WAVEBUF_COUNT;
+
+    snd3DS.pcmBuffer = (short *)linearAlloc(totalBytes);
+    if (!snd3DS.pcmBuffer)
     {
-        log3dsWrite("Unable to allocate sound buffers");
-
-        snd3dsFinalize();
+        log3dsWrite("NDSP linearAlloc failed (%d bytes)", totalBytes);
+        ndspExit();
+        snd3DS.audioType = 0;
         return false;
     }
+    memset(snd3DS.pcmBuffer, 0, totalBytes);
+    snd3DS.pcmFramesPerBuffer = framesPerBuffer;
+    snd3DS.pcmBufferCount = SND3DS_WAVEBUF_COUNT;
 
-	snd3DS.leftBuffer = &snd3DS.fullBuffers[0];
-	snd3DS.rightBuffer = &snd3DS.fullBuffers[snd3dsSampleRate];
-    memset(snd3DS.fullBuffers, 0, snd3dsSampleRate * 2 * 2);
+    ndspSetOutputMode(NDSP_OUTPUT_STEREO);
+    ndspSetOutputCount(1);
+    ndspSetMasterVol(1.0f);
 
-    if (snd3DS.audioType == 1)
+    ndspChnReset(0);
+    ndspChnSetInterp(0, NDSP_INTERP_LINEAR);
+    ndspChnSetRate(0, (float)snd3dsSampleRate);
+    ndspChnSetFormat(0, NDSP_FORMAT_STEREO_PCM16);
+
+    float stereoMix[12] = { 1.0f, 1.0f, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    ndspChnSetMix(0, stereoMix);
+
+    memset(snd3DS.waveBufs, 0, sizeof(snd3DS.waveBufs));
+    for (int i = 0; i < SND3DS_WAVEBUF_COUNT; i++)
     {
-        log3dsWrite("CSND buffers ready (playback deferred)");
+        snd3DS.waveBufs[i].data_vaddr = snd3DS.pcmBuffer + (i * framesPerBuffer * 2);
+        snd3DS.waveBufs[i].nsamples = framesPerBuffer;
+        snd3DS.waveBufs[i].looping = false;
+        snd3DS.waveBufs[i].status = NDSP_WBUF_FREE;
     }
-    else
-    {
-        float stereoMix[12] = { 1.0f, 1.0f, 0, 0, 0,   0, 0, 0, 0, 0,   0, 0 };
+    snd3DS.fillBlock = 0;
 
-        ndspSetOutputMode(NDSP_OUTPUT_STEREO);
-        ndspSetOutputCount(1);
-        ndspSetMasterVol(1.0f);
+    log3dsWrite("NDSP ready: %d Hz stereo PCM16, %d wavebufs x %d frames",
+        snd3dsSampleRate, SND3DS_WAVEBUF_COUNT, framesPerBuffer);
 
-        // Both left/right channels
-        ndspChnReset(0);
-        ndspChnSetInterp(0, NDSP_INTERP_LINEAR);
-        ndspChnSetRate(0, snd3dsSampleRate);
-        ndspChnSetFormat(0, NDSP_FORMAT_STEREO_PCM16);
-        ndspChnSetMix(0, stereoMix);
-        log3dsWrite("Set channel state");
-        memset(&snd3DS.waveBuf, 0, sizeof(ndspWaveBuf));
-        snd3DS.waveBuf.data_vaddr = (u32*)snd3DS.fullBuffers;
-        snd3DS.waveBuf.nsamples = snd3dsSampleRate;
-        snd3DS.waveBuf.looping  = true;
-        snd3DS.waveBuf.status = NDSP_WBUF_FREE;
-
-        ndspChnWaveBufAdd(0, &snd3DS.waveBuf);
-        log3dsWrite("Start playing NDSP buffers");
-    }
-
-    // SNES DSP thread
+    // Borrow CPU time on real hardware for the mixing thread, same as before.
     snd3DS.terminateMixingThread = false;
 
-    if (GPU3DS.isReal3DS) {
+    if (GPU3DS.isReal3DS)
+    {
         APT_GetAppCpuTimeLimit(&old_time_limit);
         u32 newLimitInPercent = 30;
         APT_SetAppCpuTimeLimit(newLimitInPercent);
         log3dsWrite("snd3dsInit - SetAppCpuTimeLimit: %u (old: %u)", newLimitInPercent, old_time_limit);
-
-        log3dsWrite("snd3dsInit - DSP Stack size: %x", 0x4000);
-        log3dsWrite("snd3dsInit - DSP ThreadFunc: %p", (void *)&snd3dsMixingThread);
-
-        IAPU.DSPReplayIndex = 0;
-        IAPU.DSPWriteIndex = 0;
-        snd3DS.mixingThread = threadCreate(snd3dsMixingThread, NULL, 0x4000, 0x18, 1, false);
-        if (snd3DS.mixingThread == NULL)
-        {
-            log3dsWrite("Unable to start DSP thread");
-
-            snd3dsFinalize();
-            
-            return false;
-        }
-
-        log3dsWrite("Create DSP thread %lx", (unsigned long)threadGetHandle(snd3DS.mixingThread));
-    } else {
-        log3dsWrite("No real 3DS -> Skip creating DSP thread");
     }
 
+    IAPU.DSPReplayIndex = 0;
+    IAPU.DSPWriteIndex = 0;
 
-	return true;
+    snd3DS.mixingThread = threadCreate(snd3dsMixingThread, NULL, 0x4000, 0x18, 1, false);
+    if (snd3DS.mixingThread == NULL)
+    {
+        log3dsWrite("Unable to start mixing thread");
+        snd3dsFinalize();
+        return false;
+    }
+
+    log3dsWrite("Mixing thread started: %lx", (unsigned long)threadGetHandle(snd3DS.mixingThread));
+    return true;
 }
 
 
 //---------------------------------------------------------
-// Finalize the CSND library.
+// Finalize the audio pipeline.
 //---------------------------------------------------------
 void snd3dsFinalize()
 {
-     snd3DS.terminateMixingThread = true;
+    snd3DS.terminateMixingThread = true;
 
-     if (snd3DS.mixingThread)
-     {
-         // Wait (at most 1 second) for the sound thread to finish,
-	    log3dsWrite("join mixing thread");
+    if (snd3DS.mixingThread)
+    {
+        log3dsWrite("join mixing thread");
         threadJoin(snd3DS.mixingThread, 1000 * 1000000);
         threadFree(snd3DS.mixingThread);
         snd3DS.mixingThread = NULL;
-     }
-
-    if (snd3DS.fullBuffers) {
-	    log3dsWrite("linearFree snd3DS.fullBuffers");
-
-        linearFree(snd3DS.fullBuffers);
     }
 
-    if (snd3DS.audioType == 1)
+    if (snd3DS.audioType == 2)
     {
-	    log3dsWrite("csndExit");
-        snd3dsStopPlaying();
-        csndExit();
-    }
-    else if(snd3DS.audioType == 2)
-    {
-	    log3dsWrite("ndspExit");
+        log3dsWrite("ndspExit");
         ndspChnWaveBufClear(0);
         ndspExit();
+        snd3DS.audioType = 0;
     }
 
-    if(old_time_limit != UINT32_MAX) {
-	    log3dsWrite("restore AppCPUTimeLimit: %d", old_time_limit);
+    if (snd3DS.pcmBuffer)
+    {
+        log3dsWrite("linearFree snd3DS.pcmBuffer");
+        linearFree(snd3DS.pcmBuffer);
+        snd3DS.pcmBuffer = NULL;
+    }
+
+    if (old_time_limit != UINT32_MAX)
+    {
+        log3dsWrite("restore AppCpuTimeLimit: %u", old_time_limit);
         APT_SetAppCpuTimeLimit(old_time_limit);
+        old_time_limit = UINT32_MAX;
     }
 }

--- a/source/3dssound.cpp
+++ b/source/3dssound.cpp
@@ -95,13 +95,7 @@ void snd3dsMixSamples()
 }
 
 
-//---------------------------------------------------------
-// Mixing thread entry point.
-//
-// Runs on both real hardware and emulators. NDSP is emulated
-// by Citra/Azahar (given dspfirm.cdc), so audio now works in
-// either case — no more Citra-gated thread creation.
-//---------------------------------------------------------
+// Same thread drives hardware and Citra/Azahar (given dspfirm.cdc).
 static void snd3dsMixingThread(void *p)
 {
     while (!snd3DS.terminateMixingThread)

--- a/source/3dssound.cpp
+++ b/source/3dssound.cpp
@@ -116,8 +116,13 @@ static void snd3dsMixingThread(void *p)
 //---------------------------------------------------------
 // Start playing the samples.
 //
-// Primes both NDSP wavebufs so the channel has something to
-// play immediately. The mixing thread will keep them fed.
+// Between init and the first snd3dsStartPlaying call the
+// mixing thread has been queueing silence wavebufs, so NDSP
+// is already cycling them. We must clear NDSP's internal
+// queue before resetting our local status array — otherwise
+// the mixing thread and NDSP get out of sync (NDSP thinks a
+// wavebuf is still queued while we think it's free, or we
+// double-add on top of a live queue entry).
 //---------------------------------------------------------
 void snd3dsStartPlaying()
 {
@@ -127,11 +132,14 @@ void snd3dsStartPlaying()
     if (snd3DS.audioType != 2)
         return;
 
-    // Mark both wavebufs as free so the first snd3dsMixSamples iterations
-    // fill them in order.
+    ndspChnWaveBufClear(0);
+
     for (int i = 0; i < SND3DS_WAVEBUF_COUNT; i++)
     {
-        snd3DS.waveBufs[i].status = NDSP_WBUF_FREE;
+        // DONE (not FREE) — the mixing thread treats both as refillable,
+        // and DONE accurately reflects "this wavebuf is no longer owned
+        // by NDSP" after the clear above.
+        snd3DS.waveBufs[i].status = NDSP_WBUF_DONE;
     }
     snd3DS.fillBlock = 0;
 
@@ -142,6 +150,12 @@ void snd3dsStartPlaying()
 
 //---------------------------------------------------------
 // Stop playing the samples.
+//
+// ndspChnWaveBufClear drops NDSP's internal queue but does
+// not update our local status array. Reset the array here so
+// a subsequent snd3dsStartPlaying sees the wavebufs as
+// refillable; otherwise the mixing thread would block forever
+// waiting for statuses that NDSP no longer updates.
 //---------------------------------------------------------
 void snd3dsStopPlaying()
 {
@@ -151,6 +165,11 @@ void snd3dsStopPlaying()
     if (snd3DS.audioType == 2)
     {
         ndspChnWaveBufClear(0);
+
+        for (int i = 0; i < SND3DS_WAVEBUF_COUNT; i++)
+        {
+            snd3DS.waveBufs[i].status = NDSP_WBUF_DONE;
+        }
     }
 
     snd3DS.isPlaying = false;

--- a/source/3dssound.h
+++ b/source/3dssound.h
@@ -3,7 +3,10 @@
 
 #include "3ds.h"
 
-#define SND3DS_WAVEBUF_COUNT    2
+// 8 wavebufs x samplesPerLoop (256 @ 32 kHz) = 2048 frames = ~64ms total lookahead.
+// Matches the CSND-era MIN_FORWARD_BLOCKS=8 safety margin. Lower values (tested at 2)
+// produce audible stutter when the emu thread stalls, so don't trim without testing.
+#define SND3DS_WAVEBUF_COUNT    8
 
 typedef struct
 {
@@ -67,5 +70,18 @@ void snd3dsStartPlaying();
 // Stop playing the samples.
 //---------------------------------------------------------
 void snd3dsStopPlaying();
+
+
+//---------------------------------------------------------
+// Force the mixing thread into "silence mode" and wait long
+// enough to guarantee any in-flight SNES-state access has
+// completed. Callers can then tear down / rebuild SNES state
+// (load ROM, reset console, swap memory maps) without the
+// mixer reading torn-down globals.
+//
+// Pair with snd3dsResumeMixing() once the new state is ready.
+//---------------------------------------------------------
+void snd3dsDrainMixing();
+void snd3dsResumeMixing();
 
 #endif

--- a/source/3dssound.h
+++ b/source/3dssound.h
@@ -3,29 +3,24 @@
 
 #include "3ds.h"
 
-typedef struct 
+#define SND3DS_WAVEBUF_COUNT    2
+
+typedef struct
 {
     bool        isPlaying = false;
     bool        generateSilence = false;
-    
-    int         audioType = 0;              // 0 - no audio, 1 - CSND, 2 - DSP
-    short       *fullBuffers;
-    short       *leftBuffer;
-    short       *rightBuffer;
-    u64			startTick;
-    u64         bufferPosition;
-    u64         samplePosition;
+
+    int         audioType = 0;              // 0 - no audio, 2 - NDSP (CSND path was removed in the 1.7f-era audio migration)
+
+    short       *pcmBuffer;                 // interleaved stereo s16 frames, linearAlloc'd
+    int         pcmFramesPerBuffer;         // frames per wavebuf (samplesPerLoop)
+    int         pcmBufferCount;             // SND3DS_WAVEBUF_COUNT
+    int         fillBlock;                  // which wavebuf to refill next
+
+    ndspWaveBuf waveBufs[SND3DS_WAVEBUF_COUNT];
 
     Thread      mixingThread = NULL;
     bool        terminateMixingThread;
-
-    u64         startSamplePosition = 0;
-    u64         upToSamplePosition = 0;
-
-    CSND_ChnInfo*   channelInfo;
-
-    ndspWaveBuf     waveBuf;        // structures for NDSP
-
 } SSND3DS;
 
 
@@ -34,7 +29,7 @@ extern SSND3DS snd3DS;
 //---------------------------------------------------------
 // Set the sampling rate.
 //
-// This function should be called by the 
+// This function should be called by the
 // impl3dsInitialize function. It CANNOT be called
 // after the snd3dsInitialize function is called.
 //---------------------------------------------------------
@@ -42,23 +37,22 @@ void snd3dsSetSampleRate(int sampleRate, int samplesPerLoop);
 
 
 //---------------------------------------------------------
-// Initialize the CSND library.
+// Initialize the NDSP audio pipeline.
 //---------------------------------------------------------
 bool snd3dsInitialize();
 
 
 //---------------------------------------------------------
-// Finalize the CSND library.
+// Finalize the audio pipeline.
 //---------------------------------------------------------
 void snd3dsFinalize();
 
 
 //---------------------------------------------------------
-// Mix the samples.
-//
-// This is usually called from within 3dssound.cpp.
-// It should only be called externall from other 
-// files when running in Citra.
+// Mix one block of samples and submit the corresponding
+// NDSP wavebuf. Called continuously by the mixing thread
+// on both real hardware and emulators (NDSP is emulated by
+// Citra/Azahar; CSND was not, which is why we migrated).
 //---------------------------------------------------------
 void snd3dsMixSamples();
 

--- a/source/3dssound.h
+++ b/source/3dssound.h
@@ -4,8 +4,8 @@
 #include "3ds.h"
 
 // 8 wavebufs x samplesPerLoop (256 @ 32 kHz) = 2048 frames = ~64ms total lookahead.
-// Matches the CSND-era MIN_FORWARD_BLOCKS=8 safety margin. Lower values (tested at 2)
-// produce audible stutter when the emu thread stalls, so don't trim without testing.
+// Lower values (tested at 2) produce audible stutter when the emu
+// thread stalls during menu draws or SD I/O.
 #define SND3DS_WAVEBUF_COUNT    8
 
 typedef struct
@@ -13,7 +13,7 @@ typedef struct
     bool        isPlaying = false;
     bool        generateSilence = false;
 
-    int         audioType = 0;              // 0 - no audio, 2 - NDSP (CSND path was removed in the 1.7f-era audio migration)
+    int         audioType = 0;              // 0 - no audio, 2 - NDSP
 
     short       *pcmBuffer;                 // interleaved stereo s16 frames, linearAlloc'd
     int         pcmFramesPerBuffer;         // frames per wavebuf (samplesPerLoop)
@@ -54,8 +54,7 @@ void snd3dsFinalize();
 //---------------------------------------------------------
 // Mix one block of samples and submit the corresponding
 // NDSP wavebuf. Called continuously by the mixing thread
-// on both real hardware and emulators (NDSP is emulated by
-// Citra/Azahar; CSND was not, which is why we migrated).
+// on both real hardware and Citra/Azahar (given dspfirm.cdc).
 //---------------------------------------------------------
 void snd3dsMixSamples();
 


### PR DESCRIPTION
## Summary

- Replace deprecated CSND audio backend with NDSP (modern DSP service). Fixes the "no audio in Citra/Azahar" issue and drops the last piece of CSND.
- 8-wavebuf ring (64ms lookahead) polled from a mixing thread that interleaves SNES9x's L/R staging into NDSP's stereo PCM16 wavebuf.
- Safe ROM-switch handling via `snd3dsDrainMixing()` / `snd3dsResumeMixing()` around `emulatorLoadRom` and `impl3dsResetConsole` — the mixing thread would otherwise read half-torn-down SNES9x globals and fault.
- `ndspChnWaveBufClear(0)` on play/stop keeps NDSP's internal queue and our local wavebuf-status array in sync; without this, the channel desyncs and the game goes silent.

## Why NDSP

- CSND is deprecated and not emulated by Citra/Azahar, so emulator users got no sound.
- NDSP is emulated in Azahar when `dspfirm.cdc` is present, and continues to work on real hardware.
- The NDSP init path is graceful: if `ndspInit` fails (missing firmware, service blocked) the app keeps running, just silent — no hard dependency.

## Key files

- `source/3dssound.cpp` — full rewrite: NDSP init, ring-buffer mixing thread, drain/resume helpers.
- `source/3dssound.h` — `SSND3DS` struct refactored for NDSP (`waveBufs[]`, `pcmBuffer`, `generateSilence`); wavebuf count knob.
- `source/3dsmain.cpp` — wrap `emulatorLoadRom` body with drain/resume so ROM swap is race-free.
- `source/3dsimpl.cpp` — wrap `impl3dsResetConsole` with drain/resume around `S9xReset`.

## Test plan

- [x] Hardware (N3DS): boots, SMW audio plays cleanly, no stutter under menu/SD I/O
- [x] Hardware: back-to-back ROM switches (SMW → Yoshi's Island → Castlevania IV) — no crash, audio resumes on the new ROM
- [x] Azahar: audio present with `dspfirm.cdc` loaded; silent fallback if NDSP init fails
- [x] No regression in existing `Settings.VolumeMultiplyMul4` / `settings3DS.Volume` paths
