### PR TITLE
feat: stereoscopic 3D (v3) — supersedes #42, rebased on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,16 @@ screen, with per-game depth tuning. Built on top of matbo87 v1.60.1.
   (#54), WindowLR overlap tagging fix, Fast-Forward Hold hotkey, per-game
   Framerate override (Auto / Force 60 FPS), Screen Smoothing toggle.
 
+### Known limitations
+* Games that drive per-scanline BG scroll via HDMA (Super Metroid rain in
+  Maridia, Zelda ALttP weather, etc.) may show a thin rolling artifact at
+  the right-eye margin in stereo mode. Adjacent BG tiles within the same
+  layer can shift by slightly different amounts under the per-tile depth
+  fan-out, opening 1–2 pixel gaps that fall where the HDMA scroll is
+  actively moving content. Mitigation: use the per-game crop / overscan
+  zoom controls to keep the affected margin out of view. The artifact is
+  edge-only and the rest of the stereo effect renders correctly.
+
 
 ## v1.60.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,64 @@
 # Changelog
 Notable changes to this project will be documented in this file.
 
+## Unreleased — Stereoscopic 3D (f4mrfaux fork)
+
+Full stereoscopic 3D rendering for SNES gameplay on the 3DS's dual-eye top
+screen, with per-game depth tuning. Built on top of matbo87 v1.60.1.
+
+### Features
+* **Per-layer stereoscopic depth**: each SNES BG layer, sprite layer, Mode 7
+  plane and backdrop sits at its own stereoscopic depth derived from the
+  emulator's internal compositing order. Foreground tiles pop toward the
+  viewer; distant backgrounds recede into the screen.
+* **Per-tile depth within BG layers**: tiles within a single BG layer fan out
+  across a depth range based on their compositing priority — not just a flat
+  plane per layer.
+* **Mode 7 perspective stereo**: the road / ground plane in Mode 7 scenes
+  (F-Zero, Pilotwings, Mario Kart) recedes with Y-scaled perspective depth.
+* **OBJ per-priority depth**: sprites at different SNES OBJ priorities sit at
+  different depths automatically.
+* **Per-game depth sliders**: each layer has a signed Depth gauge
+  (−40..0..+40). Center is Auto (SNES-detected). Slide LEFT to push into the
+  screen, RIGHT to pop toward the viewer. Saved per game; independent per
+  BG0 / BG1 / BG2 / BG3 / Sprites (OBJ) / Mode 7 / Backdrop.
+* **Documentation of shader invariants** — `shader_tiles.g.pica` now carries
+  a uniform-block comment spelling out the stereoOffset name/component/register
+  invariants to protect against silent-failure refactors.
+
+### Bug fixes (from rebase integration)
+* **c_depth constant in tile vertex shader** corrected from 1/32 to 1/16 — the
+  wrong value halved per-tile depth variation and shifted the zero-parallax
+  plane to an unreachable depth, inverting the apparent pop/recede direction
+  of foreground BG layers.
+* **BG layer base offset missing depthFactor** in the normal `dRange ≤ 6`
+  path — all Mode 1 BG layers landed at identical stereo offsets, producing
+  visibly flat inter-layer separation even when the depth table said otherwise.
+* **Right-eye compositing when menu stereo is off** — when the user disabled
+  stereo in the menu but left the hardware 3D slider up, the right screen
+  composited an empty texture (dark right eye). Composite now matches draw
+  conditions.
+* **Stereo config reads dropped on older config files** — the initial rebase
+  version-gated reads for pre-existing stereo settings fields, silently
+  discarding user-saved Stereo3DEnabled and per-layer scales. Gates removed.
+* **Integration of matbo87 v1.60.1 VTotal fix** (issue #54) — toggling Disable
+  3D mid-game no longer crashes / speeds up the game.
+
+### Breaking changes
+* `StereoBG*Scale` / `StereoOBJScale` / `StereoMode7Scale` / `StereoBackdropScale`
+  config fields change semantics from 0..40 (magnitude only, direction
+  auto-derived from SNES) to -40..+40 (signed: sign = direction, magnitude =
+  strength, 0 = Auto). Existing saved values from v2.1 reload as positive
+  (force pop) which doesn't match Auto for every layer. Fix: in-game menu
+  → `Reset all to Auto (center)` to start from Auto defaults.
+* Game config version bumped to 1.4.
+
+### Upstream integration
+* Rebased onto matbo87 `ce600fc` (v1.60.1). Picks up the Disable 3D freeze fix
+  (#54), WindowLR overlap tagging fix, Fast-Forward Hold hotkey, per-game
+  Framerate override (Auto / Force 60 FPS), Screen Smoothing toggle.
+
+
 ## v1.60.2
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,13 +61,19 @@ screen, with per-game depth tuning. Built on top of matbo87 v1.60.1.
   Framerate override (Auto / Force 60 FPS), Screen Smoothing toggle.
 
 ### Known limitations
-* Games that drive per-scanline BG scroll via HDMA (Super Metroid rain in
-  Maridia, Zelda ALttP weather, etc.) may show a thin rolling artifact at
-  the right-eye margin in stereo mode. Adjacent BG tiles within the same
-  layer can shift by slightly different amounts under the per-tile depth
-  fan-out, opening 1–2 pixel gaps that fall where the HDMA scroll is
-  actively moving content. Mitigation: use the per-game crop / overscan
-  zoom controls to keep the affected margin out of view. The artifact is
+* Some games show a thin disocclusion artifact at the inner or outer
+  margin of the right eye in stereo mode. Two distinct triggers:
+  * **Per-scanline BG scroll via HDMA** (Super Metroid rain in Maridia,
+    Zelda ALttP weather, etc.) — adjacent BG tiles within the same layer
+    can shift by slightly different amounts under the per-tile depth
+    fan-out, opening 1–2 pixel gaps that fall where the HDMA scroll is
+    actively moving content.
+  * **Mode 7 perspective stereo** (Super Mario Kart courses, F-Zero
+    tracks) — the Y-scaled depth shifts the closer (bottom) rows of the
+    road further than the distant (top) rows, leaving a small triangular
+    gap at the lower screen corners on one eye.
+  Mitigation in both cases: use the per-game crop / overscan zoom
+  controls to keep the affected margin out of view. The artifact is
   edge-only and the rest of the stereo effect renders correctly.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,9 @@ screen, with per-game depth tuning. Built on top of matbo87 v1.60.1.
   strength, 0 = Auto). Existing saved values from v2.1 reload as positive
   (force pop) which doesn't match Auto for every layer. Fix: in-game menu
   → `Reset all to Auto (center)` to start from Auto defaults.
-* Game config version bumped to 1.4.
+* Game config version unchanged (stays at matbo's 1.3) — the signed-gauge
+  semantics change is a reinterpretation of existing keys, not new keys,
+  so no version bump is needed to suppress parse warnings.
 
 ### Upstream integration
 * Rebased onto matbo87 `ce600fc` (v1.60.1). Picks up the Disable 3D freeze fix

--- a/README.md
+++ b/README.md
@@ -19,6 +19,45 @@ Feedback, bug reports and contributions are welcome.
 * Clean, RetroArch-style folder structure
 * Directory caching for faster ROM list loading
 * Extended hotkey options and screen swap support
+* **Stereoscopic 3D rendering with per-game depth tuning** (see below)
+
+## Stereoscopic 3D
+
+The emulator renders SNES scenes in true stereoscopic 3D using the 3DS's dual-eye
+top screen. Each BG layer, sprite layer, Mode 7 plane and backdrop can sit at its
+own depth — foreground bricks pop toward the viewer while distant skies recede
+into the screen.
+
+**Basic use** — enable it once and slide the hardware 3D slider:
+
+1. Open the in-game menu → `Options` → scroll to **Stereoscopic 3D**
+2. Check **Enable Stereoscopic 3D**
+3. Start a game and push the physical 3D slider up — scene depth appears
+   automatically. Slide down to dial it back, all the way off for flat 2D
+
+That's all most games need. The emulator reads the SNES's own layer-priority
+depth values and turns them into stereoscopic parallax per layer (*Auto* mode,
+default).
+
+**Per-game fine tuning** — if a game's stock layer ordering doesn't feel right
+(e.g. a background that should recede is popping forward, or a foreground isn't
+popping enough), open `Advanced 3D Depth (per game)` under the Stereoscopic 3D
+section:
+
+* Each layer has a **Depth** slider: **BG0 / BG1 / BG2 / BG3 / Sprites (OBJ) /
+  Mode 7 / Backdrop**
+* **Center (0)** = Auto (let the emulator decide — the default)
+* **Slide LEFT** = push that layer INTO the screen (recede)
+* **Slide RIGHT** = pop that layer TOWARD you
+* Farther from center = stronger effect
+* `Reset all to Auto (center)` zeroes all sliders
+
+All tuning is saved per-game. Games that already look good with Auto need no
+changes.
+
+> **Note:** stereo 3D is GPU-accelerated via geometry shaders on the PICA200
+> and costs nothing when the physical 3D slider is at 0 (the right-eye pass is
+> skipped entirely). Expect no frame-rate impact during normal play.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ into the screen.
 
 **Basic use** — enable it once and slide the hardware 3D slider:
 
-1. Open the in-game menu → `Options` → scroll to **Stereoscopic 3D**
+1. Open the in-game menu → `Settings` → scroll to **Stereoscopic 3D**
 2. Check **Enable Stereoscopic 3D**
 3. Start a game and push the physical 3D slider up — scene depth appears
    automatically. Slide down to dial it back, all the way off for flat 2D

--- a/source/3dsgpu.cpp
+++ b/source/3dsgpu.cpp
@@ -59,6 +59,12 @@ bool gpu3dsIs3DEnabled()
         && gfxIs3D();
 }
 
+void gpu3dsSetStereoOffset(float base, float zScale)
+{
+    C3D_FVUnifSet(GPU_GEOMETRY_SHADER, GPU3DS.shaderULocs[ULOC_STEREO_OFFSET],
+                  base, zScale, 0.0f, 0.0f);
+}
+
 void gpu3dsEnableDepthTest()
 {
     C3D_DepthTest(true, GPU_GEQUAL, GPU_WRITE_ALL);
@@ -762,6 +768,9 @@ bool gpu3dsInitializeShaderUniformLocations()
     // used by shader_mode7 (v)
     GPU3DS.shaderULocs[ULOC_UPDATE_FRAME] = shaderInstanceGetUniformLocation(GPU3DS.shaders[SPROGRAM_MODE7].shaderProgram.vertexShader, "updateFrame");
 
+    // used by shader_tiles (g) — stereo 3D horizontal offset
+    GPU3DS.shaderULocs[ULOC_STEREO_OFFSET] = shaderInstanceGetUniformLocation(GPU3DS.shaders[SPROGRAM_TILES].shaderProgram.geometryShader, "stereoOffset");
+
 	bool uLocsInvalid = false;
 
     for (int i = 0; i < ULOC_COUNT; i++) {
@@ -916,7 +925,7 @@ void gpu3dsBindTexture(SGPU_TEXTURE_ID textureId)
     SGPUTexture *texture = &GPU3DS.textures[textureId];
     
     // texture params are dynamic for main and mode7 texture
-    if (textureId == SNES_MAIN)
+    if (textureId == SNES_MAIN || textureId == SNES_MAIN_R)
     {
         GPU_TEXTURE_FILTER_PARAM filter;
         if (screenshot.dirty) {

--- a/source/3dsgpu.h
+++ b/source/3dsgpu.h
@@ -79,6 +79,7 @@ typedef enum {
     ULOC_TEX_SCALE,
     ULOC_TEX_OFFSET,
     ULOC_UPDATE_FRAME,
+    ULOC_STEREO_OFFSET,
     ULOC_COUNT
 } SGPU_SHADER_ULOC;
 
@@ -102,9 +103,10 @@ typedef enum
 	SNES_DEPTH,
 	SNES_MODE7_FULL,
 	SNES_MODE7_TILE_0,
+	SNES_MAIN_R,
 	SNES_TILE_CACHE,
     SNES_MODE7_TILE_CACHE,
-    
+
     // --- UI Textures ---
     UI_OVERLAY,
     UI_BG_GAME,
@@ -278,6 +280,7 @@ typedef struct
     CFG_SystemModel             model;
     gfx3dSide_t                 activeSide;
     bool                        gameScreenBufferDesync;
+    bool                        stereoRightEye; // tile rendering phase (redirects TARGET_SNES_MAIN); activeSide is for screen compositing phase
 } SGPU3DS;
 
 extern SGPU3DS GPU3DS;
@@ -365,15 +368,28 @@ static inline void gpu3dsWaitForVBlank(gfxScreen_t screen) {
 static inline void gpu3dsApplyRenderState(SGPURenderState *state)
 {
     u64 diff = GPU3DS.appliedRenderState.packed ^ state->packed;
+
+    // Force target re-application when stereo eye changes
+    // (right eye redirects TARGET_SNES_MAIN draws to SNES_MAIN_R texture)
+    if (GPU3DS.stereoRightEye && state->target == TARGET_SNES_MAIN)
+        diff |= PACKED_MASK_TARGET;
+
     if (!diff) return;
-    
+
     bool targetUpdated = diff & PACKED_MASK_TARGET;
-    
+
     if (targetUpdated) {
         if (state->target == TARGET_SCREEN_GAME || state->target == TARGET_SCREEN_SECOND) {
             gpu3dsSetRenderTargetToFrameBuffer(state->target);
         } else {
-            gpu3dsSetRenderTargetToTexture(state->target);
+            // Right-eye redirect: TARGET_SNES_MAIN -> SNES_MAIN_R texture
+            // This relies on SGPU_TARGET_ID and SGPU_TEXTURE_ID having matching
+            // values for the first TARGET_COUNT entries. SNES_MAIN_R is a texture
+            // ID only (not in TARGET enum) to avoid BW_TARGET 3-bit overflow.
+            SGPU_TEXTURE_ID texId = (SGPU_TEXTURE_ID)state->target;
+            if (GPU3DS.stereoRightEye && texId == SNES_MAIN)
+                texId = SNES_MAIN_R;
+            gpu3dsSetRenderTargetToTexture((SGPU_TARGET_ID)texId);
         }
     }
 
@@ -435,6 +451,7 @@ bool gpu3dsClearScreen(gfxScreen_t screen, bool isTopStereo = false);
 float gpu3dsGetIOD();
 bool gpu3dsIs3DAvailable();
 bool gpu3dsIs3DEnabled();
+void gpu3dsSetStereoOffset(float base, float zScale = 0.0f);
 
 
 #endif

--- a/source/3dsimpl.cpp
+++ b/source/3dsimpl.cpp
@@ -91,12 +91,12 @@ bool impl3dsInitialize()
 	u32 mode7Tile0TextureParams = GPU_TEXTURE_MAG_FILTER(GPU_NEAREST) | GPU_TEXTURE_MIN_FILTER(GPU_NEAREST) | GPU_TEXTURE_WRAP_S(GPU_REPEAT) | GPU_TEXTURE_WRAP_T(GPU_REPEAT);
 	
 	const SGPUTextureConfig vramTexConfig[] = {
-		{ defaultTextureParams, SNES_SUB, GPU_RGBA8, 256, 256 }, // VRAM Bank A
+		{ defaultTextureParams, SNES_SUB, GPU_RGBA8, 256, 256 },
 		{ mode7Tile0TextureParams, SNES_MODE7_TILE_0, GPU_RGBA5551, 16, 16 },
-
-		{ defaultTextureParams, SNES_MODE7_FULL, GPU_RGBA5551, 1024, 1024 }, // VRAM Bank A is full now -> VRAM Bank B
+		{ defaultTextureParams, SNES_MAIN_R, GPU_RGBA8, 256, 256 }, // stereo right eye — must be in Bank A before 2MB Mode7 texture
+		{ defaultTextureParams, SNES_MODE7_FULL, GPU_RGBA5551, 1024, 1024 },
 		{ defaultTextureParams, SNES_MAIN, GPU_RGBA8, 256, 256 },
-		{ defaultTextureParams, SNES_DEPTH, GPU_RGBA8, 256, 256 }
+		{ defaultTextureParams, SNES_DEPTH, GPU_RGBA8, 256, 256 },
 	};
 
     const int totalVramTextures = static_cast<int>(sizeof(vramTexConfig) / sizeof(vramTexConfig[0]));
@@ -112,17 +112,21 @@ bool impl3dsInitialize()
         	return false;
 		}
 
-		if (id == SNES_DEPTH) {
-			setDepthBufferByTex(GPU3DS.textures[SNES_MAIN].target, &texture->tex);
-			setDepthBufferByTex(GPU3DS.textures[SNES_SUB].target, &texture->tex);
-		}
-
 		log3dsWrite("ingame vram texture \"%s\" dim: %dx%d, size:%.2fkb, format: %s",
 			utils3dsTextureIDToString(texture->id),
 			texture->tex.width, texture->tex.height,
 			(float)texture->tex.size / 1024,
 			utils3dsTexColorToString(texture->tex.fmt)
 		);
+	}
+
+	// Share SNES_DEPTH as the depth buffer for all SNES render targets.
+	// Must run after ALL vram textures are allocated (SNES_MAIN_R included).
+	{
+		C3D_Tex *depthTex = &GPU3DS.textures[SNES_DEPTH].tex;
+		setDepthBufferByTex(GPU3DS.textures[SNES_MAIN].target, depthTex);
+		setDepthBufferByTex(GPU3DS.textures[SNES_MAIN_R].target, depthTex);
+		setDepthBufferByTex(GPU3DS.textures[SNES_SUB].target, depthTex);
 	}
 
 	const SGPUTextureConfig lramTexConfig[] = {
@@ -500,8 +504,8 @@ static void impl3dsSceneRenderEye(bool firstFrame, bool paused, SVertexList *lis
 		gameScreenViewport.tx1, gameScreenViewport.ty1, 0);
 
 	GPU3DS.currentRenderState.textureEnv = TEX_ENV_REPLACE_TEXTURE0;
-	GPU3DS.currentRenderState.textureBind = SNES_MAIN;
-
+	GPU3DS.currentRenderState.textureBind =
+		(gpu3dsIs3DEnabled() && GPU3DS.activeSide == GFX_RIGHT) ? SNES_MAIN_R : SNES_MAIN;
 	gpu3dsDraw(list, NULL, list->count);
 
 	if (balancedFilterEnabled) {

--- a/source/3dsimpl.cpp
+++ b/source/3dsimpl.cpp
@@ -504,8 +504,12 @@ static void impl3dsSceneRenderEye(bool firstFrame, bool paused, SVertexList *lis
 		gameScreenViewport.tx1, gameScreenViewport.ty1, 0);
 
 	GPU3DS.currentRenderState.textureEnv = TEX_ENV_REPLACE_TEXTURE0;
+	// Use SNES_MAIN_R for the right eye only when stereo is active in BOTH the
+	// menu AND the hardware slider. When the menu toggle is off but the slider
+	// is up, gpu3dsDrawLayers skips the right-eye pass (SNES_MAIN_R stays empty),
+	// so compositing must pull SNES_MAIN for both eyes to avoid a dark right screen.
 	GPU3DS.currentRenderState.textureBind =
-		(gpu3dsIs3DEnabled() && GPU3DS.activeSide == GFX_RIGHT) ? SNES_MAIN_R : SNES_MAIN;
+		(settings3DS.Stereo3DEnabled && gpu3dsIs3DEnabled() && GPU3DS.activeSide == GFX_RIGHT) ? SNES_MAIN_R : SNES_MAIN;
 	gpu3dsDraw(list, NULL, list->count);
 
 	if (balancedFilterEnabled) {

--- a/source/3dsimpl_gpu.cpp
+++ b/source/3dsimpl_gpu.cpp
@@ -7,18 +7,60 @@
 #include "3dsimpl.h"
 #include "3dsimpl_gpu.h"
 #include "3dslog.h"
+#include "3dssettings.h"
 
 SGPU3DSExtended GPU3DSExt;
 
+// Depth values from DRAW_* macros in S9xRenderScreenHardware() (gfxhw.cpp).
+// Table: snesDepthTable[mode][bg] = {depth0, depth1}.
+// These are the compositing priority values the emulator uses for draw ordering.
+// Higher depth = drawn later = visually in front.
+static const struct { int d0, d1; } snesDepthTable[8][4] = {
+    // Mode 0: 4 BG layers
+    {{8,11}, {7,10}, {2,5}, {1,4}},
+    // Mode 1: 3 BG layers (BG2 d1 is runtime-dependent, handled below)
+    {{8,11}, {7,10}, {2,5}, {0,0}},
+    // Mode 2
+    {{5,11}, {2,8},  {0,0}, {0,0}},
+    // Mode 3
+    {{5,11}, {2,8},  {0,0}, {0,0}},
+    // Mode 4
+    {{5,11}, {2,8},  {0,0}, {0,0}},
+    // Mode 5
+    {{5,11}, {2,8},  {0,0}, {0,0}},
+    // Mode 6: 1 BG layer
+    {{5,11}, {0,0},  {0,0}, {0,0}},
+    // Mode 7: mono (geometry shader skips stereo offset)
+    {{0,0},  {0,0},  {0,0}, {0,0}},
+};
+
+// Sprite compositing priorities interleave with BG layers at depths ~3,6,9,12.
+// Average ~6 serves as the screen plane reference (zero parallax).
+static const float STEREO_SCREEN_PLANE = 6.0f;
+
+static float getStereoLayerScale(LAYER_ID id) {
+    switch (id) {
+        case LAYER_BG0:      return settings3DS.StereoBG0Scale / 20.0f;
+        case LAYER_BG1:      return settings3DS.StereoBG1Scale / 20.0f;
+        case LAYER_BG2:      return settings3DS.StereoBG2Scale / 20.0f;
+        case LAYER_BG3:      return settings3DS.StereoBG3Scale / 20.0f;
+        case LAYER_OBJ:      return settings3DS.StereoOBJScale / 20.0f;
+        case LAYER_BACKDROP: return settings3DS.StereoBackdropScale / 20.0f;
+        default:             return 1.0f;
+    }
+}
+
 void gpu3dsDeallocLayers()
-{   
+{
     SLayerList *list = &GPU3DSExt.layerList;
 
     if (list == nullptr)
         return;
 
     linearFree(list->sections);
+    list->sections = nullptr;
     linearFree(list->ibo);
+    list->ibo = nullptr;
 }
 
 void gpu3dsResetLayer(SLayer *layer) {
@@ -303,43 +345,143 @@ void gpu3dsDrawTiledLayer(SLayer *layer, u16 *indices, int from, int to) {
 }
 
 void gpu3dsDrawLayers(SLayerList *list) {
-    // draw window_lr into depth buffer first
-    SLayer *layer = &list->layers[LAYER_WINDOW_LR];
+    bool stereoEnabled = settings3DS.Stereo3DEnabled && gpu3dsIs3DEnabled();
+    float iod = stereoEnabled ? gpu3dsGetIOD() : 0.0f;
+    int eyeCount = stereoEnabled ? 2 : 1;
 
-    if (layer->verticesByTarget[0]) {
+    // Draw window_lr into shared depth buffer once (both eyes use the same clip regions)
+    gpu3dsSetStereoOffset(0.0f);
+    SLayer *windowLayer = &list->layers[LAYER_WINDOW_LR];
+
+    if (windowLayer->verticesByTarget[0]) {
         GPU3DS.currentRenderState.target = TARGET_SNES_DEPTH;
-
-        gpu3dsDrawVerticalSectionLayer(layer, layer->sectionsOffset, layer->sectionsOffset + layer->sectionsByTarget[TARGET_SNES_MAIN]);
+        gpu3dsDrawVerticalSectionLayer(windowLayer,
+            windowLayer->sectionsOffset,
+            windowLayer->sectionsOffset + windowLayer->sectionsByTarget[TARGET_SNES_MAIN]);
     }
 
-    u8 i0 = list->anythingOnSub ? 1 : 0;
+    // Draw sub-screen layers once (mono — used for transparency effects)
+    if (list->anythingOnSub) {
+        GPU3DS.currentRenderState.target = TARGET_SNES_SUB;
 
-    for (int i = i0; i >= 0; i--) {
-        GPU3DS.currentRenderState.target = (SGPU_TARGET_ID)i;
-
-        bool sub = i == TARGET_SNES_SUB;
-
-        for (int j = 0; j < list->layersTotalByTarget[i]; j++) {
-            LAYER_ID id = list->layersByTarget[i][j];
+        for (int j = 0; j < list->layersTotalByTarget[TARGET_SNES_SUB]; j++) {
+            LAYER_ID id = list->layersByTarget[TARGET_SNES_SUB][j];
             SLayer *layer = &list->layers[id];
 
-            int from = layer->sectionsOffset + (sub ? 0 : layer->sectionsByTarget[TARGET_SNES_SUB]);
-            int to = from + layer->sectionsByTarget[i];
+            int from = layer->sectionsOffset;
+            int to = from + layer->sectionsByTarget[TARGET_SNES_SUB];
 
             if (to <= from) continue;
 
-            GPU3DS.currentRenderState.depthTest = id < LAYER_OBJ ? SGPU_STATE_ENABLED : SGPU_STATE_DISABLED;
+            GPU3DS.currentRenderState.depthTest =
+                id < LAYER_OBJ ? SGPU_STATE_ENABLED : SGPU_STATE_DISABLED;
 
             if (id < LAYER_BACKDROP) {
-                u32 bufferOffset = layer->bufferOffset + (sub ? 0 : layer->verticesByTarget[TARGET_SNES_SUB]);
-                u16 *indices = (u16 *)list->ibo + bufferOffset;
+                u16 *indices = (u16 *)list->ibo + layer->bufferOffset;
                 gpu3dsDrawTiledLayer(layer, indices, from, to);
-            }
-            else {
+            } else {
                 gpu3dsDrawVerticalSectionLayer(layer, from, to);
             }
         }
     }
+
+    // Stretch compensation: when the SNES texture is stretched wider on screen,
+    // the same clip-space offset produces more physical pixels of parallax.
+    // Multiply by (256/stretchWidth) to keep perceived depth constant.
+    int effectiveWidth = (settings3DS.ScreenStretch == Setting::ScreenStretch::Fit_8_7
+        && PPU.ScreenHeight >= SNES_HEIGHT_EXTENDED)
+        ? SNES_WIDTH : settings3DS.StretchWidth;
+    float stretchCompensation = 256.0f / effectiveWidth;
+
+    // Draw main-screen layers per eye (stereo when enabled)
+    for (int eye = 0; eye < eyeCount; eye++) {
+        bool rightEye = (eye == 1);
+        float eyeSign = rightEye ? -1.0f : 1.0f;
+
+        GPU3DS.stereoRightEye = rightEye;
+
+        if (rightEye) {
+            // Force render target re-application for right-eye redirect
+            GPU3DS.appliedRenderState.target = TARGET_UNSET;
+            GPU3DS.currentRenderTargetDim = 0;
+
+            // Clear the shared depth buffer between eye passes.
+            C3D_RenderTargetClear(GPU3DS.textures[SNES_DEPTH].target, C3D_CLEAR_ALL, 0, 0);
+            C3D_FrameDrawOn(GPU3DS.textures[SNES_DEPTH].target);
+
+            // Re-render window_lr to restore clip regions in the depth buffer.
+            if (windowLayer->verticesByTarget[0]) {
+                GPU3DS.currentRenderState.target = TARGET_SNES_DEPTH;
+                gpu3dsDrawVerticalSectionLayer(windowLayer,
+                    windowLayer->sectionsOffset,
+                    windowLayer->sectionsOffset + windowLayer->sectionsByTarget[TARGET_SNES_MAIN]);
+            }
+        }
+
+        GPU3DS.currentRenderState.target = TARGET_SNES_MAIN;
+
+        for (int j = 0; j < list->layersTotalByTarget[TARGET_SNES_MAIN]; j++) {
+            LAYER_ID id = list->layersByTarget[TARGET_SNES_MAIN][j];
+            SLayer *layer = &list->layers[id];
+
+            int from = layer->sectionsOffset + layer->sectionsByTarget[TARGET_SNES_SUB];
+            int to = from + layer->sectionsByTarget[TARGET_SNES_MAIN];
+
+            if (to <= from) continue;
+
+            GPU3DS.currentRenderState.depthTest =
+                id < LAYER_OBJ ? SGPU_STATE_ENABLED : SGPU_STATE_DISABLED;
+
+            if (stereoEnabled) {
+                if (PPU.BGMode == 7 && id <= LAYER_BG1) {
+                    // Mode 7 BG: geometry shader applies per-scanline Y-scaled depth.
+                    float mode7Scale = settings3DS.StereoMode7Scale / 20.0f;
+                    gpu3dsSetStereoOffset(mode7Scale * iod * eyeSign * stretchCompensation * (1.0f / 256.0f));
+                } else if (id == LAYER_OBJ) {
+                    // OBJ: per-priority depth via existing vertex Z.
+                    float layerScale = getStereoLayerScale(LAYER_OBJ);
+                    float common = layerScale * iod * eyeSign * stretchCompensation * (2.0f / 256.0f);
+                    float zScale = common * 16.0f / STEREO_SCREEN_PLANE;
+                    gpu3dsSetStereoOffset(common, zScale);
+                } else if (id < LAYER_OBJ) {
+                    // BG layers: per-tile depth from Z coordinate.
+                    float layerScale = getStereoLayerScale(id);
+                    float common = layerScale * iod * eyeSign * stretchCompensation * (2.0f / 256.0f);
+                    int bg = (int)id;
+                    int mode = PPU.BGMode;
+                    int d0 = (mode <= 7) ? snesDepthTable[mode][bg].d0 : 0;
+                    int d1 = (mode <= 7) ? snesDepthTable[mode][bg].d1 : 0;
+                    if (mode == 1 && bg == 2)
+                        d1 = PPU.BG3Priority ? 13 : 5;
+                    int dRange = (d1 > d0) ? (d1 - d0) : (d0 - d1);
+                    if (dRange > (int)STEREO_SCREEN_PLANE) {
+                        // Extreme range — fall back to averaged depth (zScale=0)
+                        float avgDepth = (d0 + d1) / 2.0f;
+                        float depthFactor = (STEREO_SCREEN_PLANE - avgDepth) / STEREO_SCREEN_PLANE;
+                        gpu3dsSetStereoOffset(depthFactor * common);
+                    } else {
+                        float zScale = common * 16.0f / STEREO_SCREEN_PLANE;
+                        gpu3dsSetStereoOffset(common, zScale);
+                    }
+                } else {
+                    // BACKDROP: zero stereo offset — solid color, no perceptible depth
+                    gpu3dsSetStereoOffset(0.0f);
+                }
+            }
+
+            if (id < LAYER_BACKDROP) {
+                u32 bufferOffset = layer->bufferOffset + layer->verticesByTarget[TARGET_SNES_SUB];
+                u16 *indices = (u16 *)list->ibo + bufferOffset;
+                gpu3dsDrawTiledLayer(layer, indices, from, to);
+            } else {
+                gpu3dsDrawVerticalSectionLayer(layer, from, to);
+            }
+        }
+    }
+
+    // Reset stereo state
+    GPU3DS.stereoRightEye = false;
+    gpu3dsSetStereoOffset(0.0f);
 }
 
 void gpu3dsDrawMode7Texture()

--- a/source/3dsimpl_gpu.cpp
+++ b/source/3dsimpl_gpu.cpp
@@ -463,8 +463,12 @@ void gpu3dsDrawLayers(SLayerList *list) {
                         float zScale = common * 16.0f / STEREO_SCREEN_PLANE;
                         gpu3dsSetStereoOffset(common, zScale);
                     }
+                } else if (id == LAYER_BACKDROP) {
+                    // BACKDROP: flat offset (deepest layer, no per-tile variation)
+                    float backdropScale = settings3DS.StereoBackdropScale / 20.0f;
+                    gpu3dsSetStereoOffset(1.0f * backdropScale * iod * eyeSign * stretchCompensation * (2.0f / 256.0f));
                 } else {
-                    // BACKDROP: zero stereo offset — solid color, no perceptible depth
+                    // COLOR_MATH, BRIGHTNESS: no stereo offset
                     gpu3dsSetStereoOffset(0.0f);
                 }
             }

--- a/source/3dsimpl_gpu.cpp
+++ b/source/3dsimpl_gpu.cpp
@@ -454,14 +454,21 @@ void gpu3dsDrawLayers(SLayerList *list) {
                     if (mode == 1 && bg == 2)
                         d1 = PPU.BG3Priority ? 13 : 5;
                     int dRange = (d1 > d0) ? (d1 - d0) : (d0 - d1);
+                    // Per-layer averaged depth factor. This anchors the layer's base position
+                    // relative to the screen plane (common = 0 at avgDepth = SCREEN_PLANE).
+                    // Without this, all BG layers sharing the same layerScale (e.g. all defaults
+                    // at 70%) land at the same base offset and only differ by within-layer
+                    // zScale variation — producing visibly flat inter-layer separation.
+                    float avgDepth = (d0 + d1) / 2.0f;
+                    float depthFactor = (STEREO_SCREEN_PLANE - avgDepth) / STEREO_SCREEN_PLANE;
                     if (dRange > (int)STEREO_SCREEN_PLANE) {
-                        // Extreme range — fall back to averaged depth (zScale=0)
-                        float avgDepth = (d0 + d1) / 2.0f;
-                        float depthFactor = (STEREO_SCREEN_PLANE - avgDepth) / STEREO_SCREEN_PLANE;
+                        // Extreme range — fall back to averaged depth (zScale=0, no per-tile spread).
                         gpu3dsSetStereoOffset(depthFactor * common);
                     } else {
+                        // Normal range — layer sits at depthFactor * common and tiles fan out
+                        // by zScale around that anchor via their per-tile projectedZ.
                         float zScale = common * 16.0f / STEREO_SCREEN_PLANE;
-                        gpu3dsSetStereoOffset(common, zScale);
+                        gpu3dsSetStereoOffset(depthFactor * common, zScale);
                     }
                 } else if (id == LAYER_BACKDROP) {
                     // BACKDROP: flat offset (deepest layer, no per-tile variation)

--- a/source/3dsimpl_gpu.cpp
+++ b/source/3dsimpl_gpu.cpp
@@ -504,10 +504,14 @@ void gpu3dsDrawLayers(SLayerList *list) {
             if (stereoEnabled) {
                 if (PPU.BGMode == 7 && id <= LAYER_BG1) {
                     // Mode 7 BG: geometry shader applies per-scanline Y-scaled depth.
-                    // Gauge 0 = Auto (default strength 0.5). Sign = direction.
+                    // Gauge 0 = Auto (default strength 0.5, natural recede direction).
+                    // Gauge > 0 = pop toward viewer (flips the Auto direction).
+                    // Gauge < 0 = recede into screen (same sign as Auto, stronger).
+                    // Sign convention matches BG/OBJ: positive gauge = pop; matches the
+                    // menu label "RIGHT = pop TOWARD you".
                     int m7gauge = settings3DS.StereoMode7Scale;
                     float m7strength = (m7gauge == 0) ? 0.5f : (m7gauge < 0 ? -m7gauge : m7gauge) / 20.0f;
-                    float m7sign = (m7gauge < 0) ? -1.0f : 1.0f;
+                    float m7sign = (m7gauge > 0) ? -1.0f : 1.0f;
                     gpu3dsSetStereoOffset(m7sign * m7strength * iod * eyeSign * stretchCompensation * (1.0f / 256.0f));
                 } else if (id == LAYER_OBJ) {
                     // OBJ: in Auto mode, per-priority depth via existing vertex Z.

--- a/source/3dsimpl_gpu.cpp
+++ b/source/3dsimpl_gpu.cpp
@@ -38,16 +38,85 @@ static const struct { int d0, d1; } snesDepthTable[8][4] = {
 // Average ~6 serves as the screen plane reference (zero parallax).
 static const float STEREO_SCREEN_PLANE = 6.0f;
 
-static float getStereoLayerScale(LAYER_ID id) {
+// Auto depth factor from the emulator's DRAW_* compositing values, used when
+// the user's per-layer gauge is 0 (Auto). Negative = pops toward viewer,
+// positive = recedes into screen, zero = at the screen plane.
+static float getAutoDepthFactor(LAYER_ID id) {
+    if (id == LAYER_OBJ)       return 0.0f;  // per-priority depth via vertex Z
+    if (id == LAYER_BACKDROP)  return 1.0f;   // behind everything
+    if (id >= LAYER_COLOR_MATH) return 0.0f;  // full-screen effects, no offset
+
+    int bg = (int)id;
+    int mode = PPU.BGMode;
+    if (mode > 7) return 0.0f;
+
+    int d0 = snesDepthTable[mode][bg].d0;
+    int d1 = snesDepthTable[mode][bg].d1;
+
+    // Mode 1 BG2: depth1 depends on BG3Priority flag at runtime
+    if (mode == 1 && bg == 2)
+        d1 = PPU.BG3Priority ? 13 : 5;
+
+    if (d0 == 0 && d1 == 0) return 0.0f;  // layer not used in this mode
+
+    float avgDepth = (d0 + d1) / 2.0f;
+    return (STEREO_SCREEN_PLANE - avgDepth) / STEREO_SCREEN_PLANE;
+}
+
+// Auto strength (magnitude multiplier) used when the per-layer gauge is 0.
+// These match the pre-signed-gauge defaults so "0 = Auto" reproduces the
+// v2.1 out-of-box look without forcing users to re-enter magnitude values.
+static float getAutoStrength(LAYER_ID id) {
     switch (id) {
-        case LAYER_BG0:      return settings3DS.StereoBG0Scale / 20.0f;
-        case LAYER_BG1:      return settings3DS.StereoBG1Scale / 20.0f;
-        case LAYER_BG2:      return settings3DS.StereoBG2Scale / 20.0f;
-        case LAYER_BG3:      return settings3DS.StereoBG3Scale / 20.0f;
-        case LAYER_OBJ:      return settings3DS.StereoOBJScale / 20.0f;
-        case LAYER_BACKDROP: return settings3DS.StereoBackdropScale / 20.0f;
+        case LAYER_BG0:
+        case LAYER_BG1:
+        case LAYER_BG2:
+        case LAYER_BG3:      return 0.7f;  // formerly gauge 14
+        case LAYER_OBJ:      return 0.6f;  // formerly gauge 12
+        case LAYER_BACKDROP: return 0.3f;  // formerly gauge 6
         default:             return 1.0f;
     }
+}
+
+// Raw signed gauge value for this layer (range -40..+40).
+static int getLayerGauge(LAYER_ID id) {
+    switch (id) {
+        case LAYER_BG0:      return settings3DS.StereoBG0Scale;
+        case LAYER_BG1:      return settings3DS.StereoBG1Scale;
+        case LAYER_BG2:      return settings3DS.StereoBG2Scale;
+        case LAYER_BG3:      return settings3DS.StereoBG3Scale;
+        case LAYER_OBJ:      return settings3DS.StereoOBJScale;
+        case LAYER_BACKDROP: return settings3DS.StereoBackdropScale;
+        default:             return 0;
+    }
+}
+
+// Resolved per-layer stereo state.
+//   depthFactor > 0  -> layer recedes into screen
+//   depthFactor < 0  -> layer pops toward viewer
+//   strength          -> magnitude multiplier (0..2.0)
+//   overridden        -> true if user set gauge != 0 (flat layer, no per-tile spread)
+struct LayerStereo {
+    float depthFactor;
+    float strength;
+    bool  overridden;
+};
+
+static LayerStereo resolveLayerStereo(LAYER_ID id) {
+    LayerStereo r;
+    int gauge = getLayerGauge(id);
+    if (gauge == 0) {
+        r.depthFactor = getAutoDepthFactor(id);
+        r.strength    = getAutoStrength(id);
+        r.overridden  = false;
+    } else {
+        // Gauge convention: positive = pop toward viewer, negative = recede.
+        // Internal depthFactor convention is inverted (negative = pop), so flip.
+        r.depthFactor = (gauge > 0) ? -1.0f : +1.0f;
+        r.strength    = (gauge < 0 ? -gauge : gauge) / 20.0f;
+        r.overridden  = true;
+    }
+    return r;
 }
 
 void gpu3dsDeallocLayers()
@@ -435,18 +504,28 @@ void gpu3dsDrawLayers(SLayerList *list) {
             if (stereoEnabled) {
                 if (PPU.BGMode == 7 && id <= LAYER_BG1) {
                     // Mode 7 BG: geometry shader applies per-scanline Y-scaled depth.
-                    float mode7Scale = settings3DS.StereoMode7Scale / 20.0f;
-                    gpu3dsSetStereoOffset(mode7Scale * iod * eyeSign * stretchCompensation * (1.0f / 256.0f));
+                    // Gauge 0 = Auto (default strength 0.5). Sign = direction.
+                    int m7gauge = settings3DS.StereoMode7Scale;
+                    float m7strength = (m7gauge == 0) ? 0.5f : (m7gauge < 0 ? -m7gauge : m7gauge) / 20.0f;
+                    float m7sign = (m7gauge < 0) ? -1.0f : 1.0f;
+                    gpu3dsSetStereoOffset(m7sign * m7strength * iod * eyeSign * stretchCompensation * (1.0f / 256.0f));
                 } else if (id == LAYER_OBJ) {
-                    // OBJ: per-priority depth via existing vertex Z.
-                    float layerScale = getStereoLayerScale(LAYER_OBJ);
-                    float common = layerScale * iod * eyeSign * stretchCompensation * (2.0f / 256.0f);
-                    float zScale = common * 16.0f / STEREO_SCREEN_PLANE;
-                    gpu3dsSetStereoOffset(common, zScale);
+                    // OBJ: in Auto mode, per-priority depth via existing vertex Z.
+                    // When user overrides the gauge, collapse sprites to a single forced direction.
+                    LayerStereo ls = resolveLayerStereo(LAYER_OBJ);
+                    float common = ls.strength * iod * eyeSign * stretchCompensation * (2.0f / 256.0f);
+                    if (ls.overridden) {
+                        gpu3dsSetStereoOffset(ls.depthFactor * common);
+                    } else {
+                        float zScale = common * 16.0f / STEREO_SCREEN_PLANE;
+                        gpu3dsSetStereoOffset(common, zScale);
+                    }
                 } else if (id < LAYER_OBJ) {
-                    // BG layers: per-tile depth from Z coordinate.
-                    float layerScale = getStereoLayerScale(id);
-                    float common = layerScale * iod * eyeSign * stretchCompensation * (2.0f / 256.0f);
+                    // BG layers. In Auto mode, layer anchor comes from SNES DRAW_* table
+                    // with per-tile zScale spread. In override mode (gauge != 0), the
+                    // whole layer flattens to one user-chosen direction + strength.
+                    LayerStereo ls = resolveLayerStereo(id);
+                    float common = ls.strength * iod * eyeSign * stretchCompensation * (2.0f / 256.0f);
                     int bg = (int)id;
                     int mode = PPU.BGMode;
                     int d0 = (mode <= 7) ? snesDepthTable[mode][bg].d0 : 0;
@@ -454,26 +533,21 @@ void gpu3dsDrawLayers(SLayerList *list) {
                     if (mode == 1 && bg == 2)
                         d1 = PPU.BG3Priority ? 13 : 5;
                     int dRange = (d1 > d0) ? (d1 - d0) : (d0 - d1);
-                    // Per-layer averaged depth factor. This anchors the layer's base position
-                    // relative to the screen plane (common = 0 at avgDepth = SCREEN_PLANE).
-                    // Without this, all BG layers sharing the same layerScale (e.g. all defaults
-                    // at 70%) land at the same base offset and only differ by within-layer
-                    // zScale variation — producing visibly flat inter-layer separation.
-                    float avgDepth = (d0 + d1) / 2.0f;
-                    float depthFactor = (STEREO_SCREEN_PLANE - avgDepth) / STEREO_SCREEN_PLANE;
-                    if (dRange > (int)STEREO_SCREEN_PLANE) {
-                        // Extreme range — fall back to averaged depth (zScale=0, no per-tile spread).
-                        gpu3dsSetStereoOffset(depthFactor * common);
+                    if (ls.overridden || dRange > (int)STEREO_SCREEN_PLANE) {
+                        // Override or extreme range — flat layer, no per-tile spread.
+                        gpu3dsSetStereoOffset(ls.depthFactor * common);
                     } else {
                         // Normal range — layer sits at depthFactor * common and tiles fan out
                         // by zScale around that anchor via their per-tile projectedZ.
                         float zScale = common * 16.0f / STEREO_SCREEN_PLANE;
-                        gpu3dsSetStereoOffset(depthFactor * common, zScale);
+                        gpu3dsSetStereoOffset(ls.depthFactor * common, zScale);
                     }
                 } else if (id == LAYER_BACKDROP) {
-                    // BACKDROP: flat offset (deepest layer, no per-tile variation)
-                    float backdropScale = settings3DS.StereoBackdropScale / 20.0f;
-                    gpu3dsSetStereoOffset(1.0f * backdropScale * iod * eyeSign * stretchCompensation * (2.0f / 256.0f));
+                    // BACKDROP: flat offset, always deepest in Auto (depthFactor=+1).
+                    // A user override on the Backdrop gauge still forces flat at the chosen direction/strength.
+                    LayerStereo ls = resolveLayerStereo(LAYER_BACKDROP);
+                    float common = ls.strength * iod * eyeSign * stretchCompensation * (2.0f / 256.0f);
+                    gpu3dsSetStereoOffset(ls.depthFactor * common);
                 } else {
                     // COLOR_MATH, BRIGHTNESS: no stereo offset
                     gpu3dsSetStereoOffset(0.0f);

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -789,6 +789,43 @@ void makeOptionMenu(std::vector<SMenuItem>& items, std::vector<SMenuTab>& menuTa
 
     AddMenuDisabledOption(items, ""_s);
 
+    AddMenuHeader2(items, "Stereoscopic 3D"_s);
+    AddMenuCheckbox(items, "  Enable Stereoscopic 3D"_s, settings3DS.Stereo3DEnabled,
+        []( int val ) { CheckAndUpdateToggle( settings3DS.Stereo3DEnabled, val ); });
+    AddMenuDisabledOption(items, "  Use the 3D slider to control depth intensity"_s);
+
+    if (settings3DS.Stereo3DEnabled) {
+        AddMenuDisabledOption(items, ""_s);
+        AddMenuHeader2(items, "Advanced 3D Depth Tuning"_s);
+        AddMenuGauge(items, "  BG0 Scale"_s, 0, 40, settings3DS.StereoBG0Scale,
+            []( int val ) { CheckAndUpdate( settings3DS.StereoBG0Scale, val ); });
+        AddMenuGauge(items, "  BG1 Scale"_s, 0, 40, settings3DS.StereoBG1Scale,
+            []( int val ) { CheckAndUpdate( settings3DS.StereoBG1Scale, val ); });
+        AddMenuGauge(items, "  BG2 Scale"_s, 0, 40, settings3DS.StereoBG2Scale,
+            []( int val ) { CheckAndUpdate( settings3DS.StereoBG2Scale, val ); });
+        AddMenuGauge(items, "  BG3 Scale"_s, 0, 40, settings3DS.StereoBG3Scale,
+            []( int val ) { CheckAndUpdate( settings3DS.StereoBG3Scale, val ); });
+        AddMenuGauge(items, "  OBJ Scale"_s, 0, 40, settings3DS.StereoOBJScale,
+            []( int val ) { CheckAndUpdate( settings3DS.StereoOBJScale, val ); });
+        AddMenuGauge(items, "  Mode 7 Scale"_s, 0, 40, settings3DS.StereoMode7Scale,
+            []( int val ) { CheckAndUpdate( settings3DS.StereoMode7Scale, val ); });
+        AddMenuGauge(items, "  Backdrop Scale"_s, 0, 40, settings3DS.StereoBackdropScale,
+            []( int val ) { CheckAndUpdate( settings3DS.StereoBackdropScale, val ); });
+        items.emplace_back([](int) {
+                settings3DS.StereoBG0Scale = 14;
+                settings3DS.StereoBG1Scale = 14;
+                settings3DS.StereoBG2Scale = 14;
+                settings3DS.StereoBG3Scale = 14;
+                settings3DS.StereoOBJScale = 12;
+                settings3DS.StereoMode7Scale = 10;
+                settings3DS.StereoBackdropScale = 6;
+                settings3DS.isDirty = true;
+                settings3DS.uiNeedsRebuild = true;
+            }, MenuItemType::Action, "  Reset 3D Depth Scales"_s, ""_s);
+    }
+
+    AddMenuDisabledOption(items, ""_s);
+
     AddMenuHeader2(items, "Audio"_s);
     AddMenuGauge(items, "  Volume Amplification"_s, 0, 8, 
                 settings3DS.UseGlobalVolume ? settings3DS.GlobalVolume : settings3DS.Volume,
@@ -1135,6 +1172,20 @@ bool settingsReadWriteFullListByGame(bool writeMode)
         config3dsReadWriteBitmask(stream, writeMode, keyBuf, &settings3DS.ButtonHotkeys[i].MappingBitmasks[0]);
     }
 
+    // Stereoscopic 3D per-game settings.
+    // These fields existed in v2.1 (released prior to matbo's v1.60.1). Saved configs
+    // from that build already contain these keys under older config versions. Do NOT
+    // version-gate the reads — missing keys are safely ignored by config3dsReadWriteInt32
+    // (logs a one-off parse-mismatch warning but preserves the current value), while
+    // gating would silently discard legitimately-saved user settings.
+    config3dsReadWriteInt32(stream, writeMode, "StereoBG0Scale=%d\n", &settings3DS.StereoBG0Scale, 0, 40);
+    config3dsReadWriteInt32(stream, writeMode, "StereoBG1Scale=%d\n", &settings3DS.StereoBG1Scale, 0, 40);
+    config3dsReadWriteInt32(stream, writeMode, "StereoBG2Scale=%d\n", &settings3DS.StereoBG2Scale, 0, 40);
+    config3dsReadWriteInt32(stream, writeMode, "StereoBG3Scale=%d\n", &settings3DS.StereoBG3Scale, 0, 40);
+    config3dsReadWriteInt32(stream, writeMode, "StereoOBJScale=%d\n", &settings3DS.StereoOBJScale, 0, 40);
+    config3dsReadWriteInt32(stream, writeMode, "StereoMode7Scale=%d\n", &settings3DS.StereoMode7Scale, 0, 40);
+    config3dsReadWriteInt32(stream, writeMode, "StereoBackdropScale=%d\n", &settings3DS.StereoBackdropScale, 0, 40);
+
     return true;
 }
 
@@ -1263,6 +1314,14 @@ bool settingsReadWriteFullListGlobal(bool writeMode)
     config3dsReadWriteEnum(stream, writeMode, "UseGlobalEmuControlKeys=%d\n", &settings3DS.UseGlobalEmuControlKeys, 0, 1);
 
     config3dsReadWriteEnum(stream, writeMode, "ShowFPS=%d\n", &settings3DS.ShowFPS, 0, 1);
+
+    // Stereoscopic 3D global setting
+    // Stereoscopic 3D global enable flag.
+    // Existed in v2.1 — saved configs already carry this key. Not version-gated:
+    // the user's existing Stereo3DEnabled=1 must be read even on older config
+    // versions, otherwise stereo silently disables (right eye stays dark because
+    // the draw loop skips the right-eye pass when this field is false).
+    config3dsReadWriteEnum(stream, writeMode, "Stereo3DEnabled=%d\n", &settings3DS.Stereo3DEnabled, 0, 1);
 
     return true;
 }
@@ -1927,6 +1986,7 @@ void emulatorLoop()
     }
 
     gpu3dsResetState();
+    gfxSet3D(!settings3DS.Disable3DSlider && settings3DS.GameScreen == GFX_TOP);
 
     if (GPU3DS.profilingMode == PROFILING_OFF) {
 		// clear + draw second screen

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -792,36 +792,43 @@ void makeOptionMenu(std::vector<SMenuItem>& items, std::vector<SMenuTab>& menuTa
     AddMenuHeader2(items, "Stereoscopic 3D"_s);
     AddMenuCheckbox(items, "  Enable Stereoscopic 3D"_s, settings3DS.Stereo3DEnabled,
         []( int val ) { CheckAndUpdateToggle( settings3DS.Stereo3DEnabled, val ); settings3DS.uiNeedsRebuild = true; });
-    AddMenuDisabledOption(items, "  Use the 3D slider to control depth intensity"_s);
+    AddMenuDisabledOption(items, "  Use the 3DS hardware 3D slider to control overall intensity."_s);
 
     if (settings3DS.Stereo3DEnabled) {
         AddMenuDisabledOption(items, ""_s);
-        AddMenuHeader2(items, "Advanced 3D Depth Tuning"_s);
-        AddMenuGauge(items, "  BG0 Scale"_s, 0, 40, settings3DS.StereoBG0Scale,
+        AddMenuHeader2(items, "Advanced 3D Depth (per game)"_s);
+        items.emplace_back(nullptr, MenuItemType::Textarea,
+            "  Each bar: CENTER (0) = Auto — detect depth from SNES."_s, ""_s);
+        items.emplace_back(nullptr, MenuItemType::Textarea,
+            "  LEFT = push INTO screen, RIGHT = pop TOWARD you."_s, ""_s);
+        items.emplace_back(nullptr, MenuItemType::Textarea,
+            "  Farther from center = stronger effect. Saved per game."_s, ""_s);
+
+        AddMenuGauge(items, "  BG0 Depth"_s, -40, 40, settings3DS.StereoBG0Scale,
             []( int val ) { CheckAndUpdate( settings3DS.StereoBG0Scale, val ); });
-        AddMenuGauge(items, "  BG1 Scale"_s, 0, 40, settings3DS.StereoBG1Scale,
+        AddMenuGauge(items, "  BG1 Depth"_s, -40, 40, settings3DS.StereoBG1Scale,
             []( int val ) { CheckAndUpdate( settings3DS.StereoBG1Scale, val ); });
-        AddMenuGauge(items, "  BG2 Scale"_s, 0, 40, settings3DS.StereoBG2Scale,
+        AddMenuGauge(items, "  BG2 Depth"_s, -40, 40, settings3DS.StereoBG2Scale,
             []( int val ) { CheckAndUpdate( settings3DS.StereoBG2Scale, val ); });
-        AddMenuGauge(items, "  BG3 Scale"_s, 0, 40, settings3DS.StereoBG3Scale,
+        AddMenuGauge(items, "  BG3 Depth"_s, -40, 40, settings3DS.StereoBG3Scale,
             []( int val ) { CheckAndUpdate( settings3DS.StereoBG3Scale, val ); });
-        AddMenuGauge(items, "  OBJ Scale"_s, 0, 40, settings3DS.StereoOBJScale,
+        AddMenuGauge(items, "  Sprites (OBJ) Depth"_s, -40, 40, settings3DS.StereoOBJScale,
             []( int val ) { CheckAndUpdate( settings3DS.StereoOBJScale, val ); });
-        AddMenuGauge(items, "  Mode 7 Scale"_s, 0, 40, settings3DS.StereoMode7Scale,
+        AddMenuGauge(items, "  Mode 7 Depth"_s, -40, 40, settings3DS.StereoMode7Scale,
             []( int val ) { CheckAndUpdate( settings3DS.StereoMode7Scale, val ); });
-        AddMenuGauge(items, "  Backdrop Scale"_s, 0, 40, settings3DS.StereoBackdropScale,
+        AddMenuGauge(items, "  Backdrop Depth"_s, -40, 40, settings3DS.StereoBackdropScale,
             []( int val ) { CheckAndUpdate( settings3DS.StereoBackdropScale, val ); });
         items.emplace_back([](int) {
-                settings3DS.StereoBG0Scale = 14;
-                settings3DS.StereoBG1Scale = 14;
-                settings3DS.StereoBG2Scale = 14;
-                settings3DS.StereoBG3Scale = 14;
-                settings3DS.StereoOBJScale = 12;
-                settings3DS.StereoMode7Scale = 10;
-                settings3DS.StereoBackdropScale = 6;
+                settings3DS.StereoBG0Scale = 0;
+                settings3DS.StereoBG1Scale = 0;
+                settings3DS.StereoBG2Scale = 0;
+                settings3DS.StereoBG3Scale = 0;
+                settings3DS.StereoOBJScale = 0;
+                settings3DS.StereoMode7Scale = 0;
+                settings3DS.StereoBackdropScale = 0;
                 settings3DS.isDirty = true;
                 settings3DS.uiNeedsRebuild = true;
-            }, MenuItemType::Action, "  Reset 3D Depth Scales"_s, ""_s);
+            }, MenuItemType::Action, "  Reset all to Auto (center)"_s, ""_s);
     }
 
     AddMenuDisabledOption(items, ""_s);

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -1185,13 +1185,16 @@ bool settingsReadWriteFullListByGame(bool writeMode)
     // version-gate the reads — missing keys are safely ignored by config3dsReadWriteInt32
     // (logs a one-off parse-mismatch warning but preserves the current value), while
     // gating would silently discard legitimately-saved user settings.
-    config3dsReadWriteInt32(stream, writeMode, "StereoBG0Scale=%d\n", &settings3DS.StereoBG0Scale, 0, 40);
-    config3dsReadWriteInt32(stream, writeMode, "StereoBG1Scale=%d\n", &settings3DS.StereoBG1Scale, 0, 40);
-    config3dsReadWriteInt32(stream, writeMode, "StereoBG2Scale=%d\n", &settings3DS.StereoBG2Scale, 0, 40);
-    config3dsReadWriteInt32(stream, writeMode, "StereoBG3Scale=%d\n", &settings3DS.StereoBG3Scale, 0, 40);
-    config3dsReadWriteInt32(stream, writeMode, "StereoOBJScale=%d\n", &settings3DS.StereoOBJScale, 0, 40);
-    config3dsReadWriteInt32(stream, writeMode, "StereoMode7Scale=%d\n", &settings3DS.StereoMode7Scale, 0, 40);
-    config3dsReadWriteInt32(stream, writeMode, "StereoBackdropScale=%d\n", &settings3DS.StereoBackdropScale, 0, 40);
+    // Gauge range is signed [-40, +40]. Negative = recede into screen,
+    // 0 = Auto, positive = pop toward viewer. Bounds must match the menu
+    // gauge range; otherwise negative values get clamped to 0 on save/load.
+    config3dsReadWriteInt32(stream, writeMode, "StereoBG0Scale=%d\n", &settings3DS.StereoBG0Scale, -40, 40);
+    config3dsReadWriteInt32(stream, writeMode, "StereoBG1Scale=%d\n", &settings3DS.StereoBG1Scale, -40, 40);
+    config3dsReadWriteInt32(stream, writeMode, "StereoBG2Scale=%d\n", &settings3DS.StereoBG2Scale, -40, 40);
+    config3dsReadWriteInt32(stream, writeMode, "StereoBG3Scale=%d\n", &settings3DS.StereoBG3Scale, -40, 40);
+    config3dsReadWriteInt32(stream, writeMode, "StereoOBJScale=%d\n", &settings3DS.StereoOBJScale, -40, 40);
+    config3dsReadWriteInt32(stream, writeMode, "StereoMode7Scale=%d\n", &settings3DS.StereoMode7Scale, -40, 40);
+    config3dsReadWriteInt32(stream, writeMode, "StereoBackdropScale=%d\n", &settings3DS.StereoBackdropScale, -40, 40);
 
     return true;
 }

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -791,7 +791,7 @@ void makeOptionMenu(std::vector<SMenuItem>& items, std::vector<SMenuTab>& menuTa
 
     AddMenuHeader2(items, "Stereoscopic 3D"_s);
     AddMenuCheckbox(items, "  Enable Stereoscopic 3D"_s, settings3DS.Stereo3DEnabled,
-        []( int val ) { CheckAndUpdateToggle( settings3DS.Stereo3DEnabled, val ); });
+        []( int val ) { CheckAndUpdateToggle( settings3DS.Stereo3DEnabled, val ); settings3DS.uiNeedsRebuild = true; });
     AddMenuDisabledOption(items, "  Use the 3D slider to control depth intensity"_s);
 
     if (settings3DS.Stereo3DEnabled) {

--- a/source/3dssettings.cpp
+++ b/source/3dssettings.cpp
@@ -79,7 +79,6 @@ void settings3dsResetGameDefaults() {
     settings3DS.SRAMSaveInterval = 0;
     settings3DS.ForceSRAMWriteOnPause = false;
 
-    settings3DS.Stereo3DEnabled = false;
     settings3DS.StereoBG0Scale = 14;
     settings3DS.StereoBG1Scale = 14;
     settings3DS.StereoBG2Scale = 14;

--- a/source/3dssettings.cpp
+++ b/source/3dssettings.cpp
@@ -79,13 +79,16 @@ void settings3dsResetGameDefaults() {
     settings3DS.SRAMSaveInterval = 0;
     settings3DS.ForceSRAMWriteOnPause = false;
 
-    settings3DS.StereoBG0Scale = 14;
-    settings3DS.StereoBG1Scale = 14;
-    settings3DS.StereoBG2Scale = 14;
-    settings3DS.StereoBG3Scale = 14;
-    settings3DS.StereoOBJScale = 12;
-    settings3DS.StereoMode7Scale = 10;
-    settings3DS.StereoBackdropScale = 6;
+    // Stereo per-layer gauge defaults: 0 = Auto (use SNES DRAW_* depth table).
+    // Users can shift each gauge to override: negative = force recede into screen,
+    // positive = force pop toward viewer, magnitude = strength (|v|/20 = 0..2x).
+    settings3DS.StereoBG0Scale = 0;
+    settings3DS.StereoBG1Scale = 0;
+    settings3DS.StereoBG2Scale = 0;
+    settings3DS.StereoBG3Scale = 0;
+    settings3DS.StereoOBJScale = 0;
+    settings3DS.StereoMode7Scale = 0;
+    settings3DS.StereoBackdropScale = 0;
 
     // reset controls to global defaults (settings.cfg)
     //
@@ -222,8 +225,11 @@ void settings3dsUpdate(bool includeGameSettings)
                 settings3DS.ButtonHotkeys[i] = settings3DS.GlobalButtonHotkeys[i];
         }
 
-        // Clamp stereo gauge values to valid range [0, 40]
-        auto clampGauge = [](int &v) { if (v < 0) v = 0; if (v > 40) v = 40; };
+        // Clamp stereo gauge values to valid range [-40, 40].
+        // 0 = Auto (use SNES DRAW_* depth table). Non-zero overrides Auto:
+        // positive = pop toward viewer, negative = recede into screen,
+        // magnitude = strength (|v|/20 = 0.0..2.0 multiplier).
+        auto clampGauge = [](int &v) { if (v < -40) v = -40; if (v > 40) v = 40; };
         clampGauge(settings3DS.StereoBG0Scale);
         clampGauge(settings3DS.StereoBG1Scale);
         clampGauge(settings3DS.StereoBG2Scale);

--- a/source/3dssettings.cpp
+++ b/source/3dssettings.cpp
@@ -22,6 +22,7 @@ void settings3dsResetGlobalDefaults() {
     
     settings3DS.Disable3DSlider = false;
     settings3DS.LogFileEnabled = false;
+    settings3DS.Stereo3DEnabled = false;
 
     settings3DS.ScreenStretch = Setting::ScreenStretch::Aspect_4_3;
     settings3DS.ScreenFilter = Setting::ScreenFilter::Smooth;
@@ -77,6 +78,15 @@ void settings3dsResetGameDefaults() {
     settings3DS.AutoSavestate = false;
     settings3DS.SRAMSaveInterval = 0;
     settings3DS.ForceSRAMWriteOnPause = false;
+
+    settings3DS.Stereo3DEnabled = false;
+    settings3DS.StereoBG0Scale = 14;
+    settings3DS.StereoBG1Scale = 14;
+    settings3DS.StereoBG2Scale = 14;
+    settings3DS.StereoBG3Scale = 14;
+    settings3DS.StereoOBJScale = 12;
+    settings3DS.StereoMode7Scale = 10;
+    settings3DS.StereoBackdropScale = 6;
 
     // reset controls to global defaults (settings.cfg)
     //
@@ -209,10 +219,20 @@ void settings3dsUpdate(bool includeGameSettings)
         }
 
         if (settings3DS.UseGlobalEmuControlKeys) {
-             for (int i = 0; i < HOTKEYS_COUNT; ++i) 
+             for (int i = 0; i < HOTKEYS_COUNT; ++i)
                 settings3DS.ButtonHotkeys[i] = settings3DS.GlobalButtonHotkeys[i];
         }
-        
+
+        // Clamp stereo gauge values to valid range [0, 40]
+        auto clampGauge = [](int &v) { if (v < 0) v = 0; if (v > 40) v = 40; };
+        clampGauge(settings3DS.StereoBG0Scale);
+        clampGauge(settings3DS.StereoBG1Scale);
+        clampGauge(settings3DS.StereoBG2Scale);
+        clampGauge(settings3DS.StereoBG3Scale);
+        clampGauge(settings3DS.StereoOBJScale);
+        clampGauge(settings3DS.StereoMode7Scale);
+        clampGauge(settings3DS.StereoBackdropScale);
+
         // Fixes the Auto-Save timer bug that causes
         // the SRAM to be saved once when the settings were
         // changed to Disabled.

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -141,19 +141,10 @@ typedef struct {
     bool Disable3DSlider;
     bool LogFileEnabled;    // Write logs to sdmc:/3ds/snes9x_3ds/debug_<APP_VERSION>_session.log
 
-    // Stereoscopic 3D
-    bool    Stereo3DEnabled;            // Per-game opt-in toggle (off by default)
-
-    // Per-layer depth scales (0-40 gauge, /20 = 0.0x-2.0x)
-    // Advanced tuning — only shown in menu when Stereo3DEnabled is true.
-    // Overall intensity is controlled by the physical 3D slider (IOD).
-    int     StereoBG0Scale;
-    int     StereoBG1Scale;
-    int     StereoBG2Scale;
-    int     StereoBG3Scale;
-    int     StereoOBJScale;
-    int     StereoMode7Scale;
-    int     StereoBackdropScale;
+    // Stereoscopic 3D — global enable flag (stored in settings.cfg, not per-game).
+    // Off by default; user opts in from the in-game menu. Per-layer depth
+    // tuning fields live in the GAME-SPECIFIC section below.
+    bool    Stereo3DEnabled;
 
     int CurrentSaveSlot;    // remember last used save slot (1 - 5)
 
@@ -191,6 +182,19 @@ typedef struct {
                                                 // 1 - Force 60 FPS
     Setting::FrameSync  FrameSync;              // 0 - VBlank
                                                 // 1 - Sleep
+
+    // Per-layer stereo depth gauges. Signed range [-40, +40].
+    //   0  = Auto (depth derived from the SNES DRAW_* table)
+    //   >0 = force pop toward viewer, magnitude = |v|/20 strength multiplier
+    //   <0 = force recede into screen, same magnitude rule
+    // Only consulted when the global Stereo3DEnabled flag is true.
+    int                 StereoBG0Scale;
+    int                 StereoBG1Scale;
+    int                 StereoBG2Scale;
+    int                 StereoBG3Scale;
+    int                 StereoOBJScale;
+    int                 StereoMode7Scale;
+    int                 StereoBackdropScale;
 
     int                 PaletteFix;             // Palette In-Frame Changes
                                                 //   1 - Enabled - Default.

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -140,6 +140,21 @@ typedef struct {
     gfxScreen_t GameScreen;
     bool Disable3DSlider;
     bool LogFileEnabled;    // Write logs to sdmc:/3ds/snes9x_3ds/debug_<APP_VERSION>_session.log
+
+    // Stereoscopic 3D
+    bool    Stereo3DEnabled;            // Per-game opt-in toggle (off by default)
+
+    // Per-layer depth scales (0-40 gauge, /20 = 0.0x-2.0x)
+    // Advanced tuning — only shown in menu when Stereo3DEnabled is true.
+    // Overall intensity is controlled by the physical 3D slider (IOD).
+    int     StereoBG0Scale;
+    int     StereoBG1Scale;
+    int     StereoBG2Scale;
+    int     StereoBG3Scale;
+    int     StereoOBJScale;
+    int     StereoMode7Scale;
+    int     StereoBackdropScale;
+
     int CurrentSaveSlot;    // remember last used save slot (1 - 5)
 
     // --- FILE MENU ---

--- a/source/3dsutils.cpp
+++ b/source/3dsutils.cpp
@@ -162,6 +162,7 @@ const char* utils3dsTextureIDToString(SGPU_TEXTURE_ID id) {
         case SNES_DEPTH:                return "depth";
         case SNES_MODE7_FULL:           return "m7 full";
         case SNES_MODE7_TILE_0:         return "m7 zero";
+        case SNES_MAIN_R:              return "main R";
         case SNES_TILE_CACHE:           return "tile cache";
         case SNES_MODE7_TILE_CACHE:     return "m7 tile cache";
         case UI_OVERLAY:                return "overlay";

--- a/source/shader_tiles.g.pica
+++ b/source/shader_tiles.g.pica
@@ -1,4 +1,23 @@
 ; Uniforms
+;
+; Register indices are determined by declaration order and array size:
+;   projection[4]  occupies registers 0..3
+;   textureScale   occupies register  4
+;   stereoOffset   occupies register  5
+;
+; STEREO INVARIANTS — changing any of these silently breaks per-tile stereo depth:
+;   - The name "stereoOffset" MUST match the string passed to
+;     shaderInstanceGetUniformLocation() in 3dsgpu.cpp (ULOC_STEREO_OFFSET lookup).
+;     A mismatch returns -1 and the init validation bails with "uniform not found".
+;   - The .xy component layout is load-bearing:
+;       .x = stereoBase    (common horizontal offset factor)
+;       .y = stereoZScale  (per-tile depth scale = stereoBase * 16 / SCREEN_PLANE)
+;     Reorder components -> both eyes render identically (silent failure).
+;   - The GEOMETRY shader uniform register file is SEPARATE from the vertex shader
+;     on PICA200. C3D_FVUnifSet() must use GPU_GEOMETRY_SHADER, not GPU_VERTEX_SHADER.
+;   - Declaration order is safe to change ONLY if no raw GPU register writes reference
+;     register #5 directly. All current code uses shaderInstanceGetUniformLocation,
+;     so reordering works, but keep the ordering stable to aid debugger inspection.
 .fvec       projection[4]       ; #0 - 3
 .fvec       textureScale        ; #4
 .fvec       stereoOffset        ; #5  (x = stereoBase, y = stereoZScale for per-tile depth)

--- a/source/shader_tiles.g.pica
+++ b/source/shader_tiles.g.pica
@@ -1,6 +1,7 @@
 ; Uniforms
 .fvec       projection[4]       ; #0 - 3
 .fvec       textureScale        ; #4
+.fvec       stereoOffset        ; #5  (x = stereoBase, y = stereoZScale for per-tile depth)
 
 ; Constants
 .constf c_base          (0.004032258064516, 1, -1, 0.00395) ; x: 5-bit color conversion
@@ -53,6 +54,16 @@
     cmp     r3.y, lt, lt, r7.z          ; if (r3.y (after projection) < -1) then
     jmpc    cmp.x, mode7
 
+    ; ── Per-tile-depth stereo offset (skipped for mode7 tiles) ──
+    ; stereoOffset.x = stereoBase (common factor without averaged depth)
+    ; stereoOffset.y = stereoZScale (stereoBase * 16 / SCREEN_PLANE)
+    ; r0.z = projected Z = -d/16 (per-tile depth extracted by vertex shader)
+    ; offset = stereoBase + stereoZScale * r0.z = common * (1 - d/SCREEN_PLANE)
+    mov     r8, stereoOffset
+    mul     r9.x, r8.y, r0.z
+    add     r9.x, r8.x, r9.x
+    add     r0.x, r0.x, r9.x
+    add     r3.x, r3.x, r9.x
 
     ; Emit the standard:
     ;   x0,y0,tx0,ty0       x1,y0,tx1,ty0
@@ -105,13 +116,28 @@ mode7:
     ;                    +---+
     ;   x0,y1,z0,tx0,ty0        x1,y1,z0,tx1,ty1
     ;
+    ; ── Stereo 3D perspective depth for Mode 7 ──
+    ; r0.y = projected screen Y (clip space, Mtx_Ortho(0,256,0,256))
+    ;   top (Y=0, far ground):    r0.y = -1.0
+    ;   bottom (Y=239, near):     r0.y = +0.867  (not +1.0; vpHeight=256)
+    ; depthScale = (1 - r0.y) → [0.133..2.0]: ~0 at bottom, 2 at top
+    ; CPU sets stereoOffset.x = mode7Scale * iod * eyeSign * stretchComp * (1/256)
+    ; The ~2x range roughly absorbs the factor of 2 vs tile layers' 2/256 constant.
+    ; Bottom residual (0.133) is ~0.26px at typical settings — imperceptible.
+
+    mov     r8, stereoOffset        ; PICA200 geom ALU: must mov uniform to temp
+    add     r9.x, r7.y, -r0.y      ; r9.x = 1.0 - projectedY (depth scale)
+    mul     r8.x, r8.x, r9.x       ; finalOffset = stereoBase * depthScale
+    add     r0.x, r0.x, r8.x       ; shift left edge
+    add     r3.x, r3.x, r8.x       ; shift right edge
+
     add     r3.y, r0.y, r7.w            ; r3.y = r0.y + 1 scan line
 
     setemit 0                           ; top-left
     mov     outpos.xyz, r0.xyz
     mov     outtex.xy, r1.xy
     mov     outcol, r2
-    emit 
+    emit
 
     setemit 1                           ; top-right
     mov     outpos.x, r3.x

--- a/source/shader_tiles.g.pica
+++ b/source/shader_tiles.g.pica
@@ -78,6 +78,12 @@
     ; stereoOffset.y = stereoZScale (stereoBase * 16 / SCREEN_PLANE)
     ; r0.z = projected Z = -d/16 (per-tile depth extracted by vertex shader)
     ; offset = stereoBase + stereoZScale * r0.z = common * (1 - d/SCREEN_PLANE)
+    ;
+    ; Note: do NOT scale this offset by any per-tile position-dependent
+    ; factor (screen X, |r0.x|, etc.). Adjacent tiles within the same
+    ; layer must all shift by the same amount, or they misalign into
+    ; visible vertical seams. The edge-fade attempt in an earlier
+    ; revision of this shader introduced exactly that regression.
     mov     r8, stereoOffset
     mul     r9.x, r8.y, r0.z
     add     r9.x, r8.x, r9.x

--- a/source/shader_tiles.v.pica
+++ b/source/shader_tiles.v.pica
@@ -8,7 +8,7 @@
 .constf c_base          (0, 1, 2, 8)    ; (x, y, z, w)
 .constf c_tex           (32768, 16384, 0.0078125, 128)
 .constf c_alpha         (24576, 8192, 255, 0)
-.constf c_depth         (0.03125, -256, 0.00390625, 0)
+.constf c_depth         (0.0625, -256, 0.00390625, 0)
 
 ; Outputs
 .out        outpos      position


### PR DESCRIPTION
Supersedes #42. Opening as **Draft** per your original request.

## Addressing your March 15 feedback

| Your ask | Status in this branch |
|---|---|
| Fix depth/layer ordering & graphical glitches | Fixed. Green-line edge artifact traced to two stereo math bugs (`c_depth` constant 1/32 → 1/16 in `d4614e7`, missing `depthFactor` in else-branch `b97b7b6`). Hardware-validated on N3DS XL 2026-04-14 across SMW, Yoshi's Island, F-Zero, Super Castlevania IV, Chrono Trigger intro. Castlevania fog regression also fixed. |
| Split out unrelated bugfixes & debug tooling | Done. Branch touches **13 files** (13 new stereo files, 695 insertions), vs 17+ in #42. No `3dslog.cpp`, no `3dssound.cpp`, no `gfxhw.cpp`, no `3dsimpl_tilecache.cpp`. NDSP audio migration went in as #58 (merged). Mosaic HDMA rendering went in as #59 (merged). |
| Remove per-layer settings, single per-game opt-in toggle | **Compromise** — please re-litigate if needed. Main menu shows a single "Enable Stereoscopic 3D" per-game toggle, off by default. When enabled, an **Advanced** submenu shows 7 signed Depth gauges (`-40..+40`, `0 = Auto`) for power users. The base experience is the checkbox — users don't see any gauges unless they opt in. But if you'd rather I strip the advanced submenu entirely, say the word and I'll drop it. |
| Don't remove `3dsui_img.cpp` custom assets feature | Confirmed — file isn't in the diff. |
| Rebase onto master | Done. 15 commits on top of current `fb200ab`. |

## What this branch is

Per-layer stereoscopic 3D using shader-uniform replay — vertices built once on CPU, drawn twice on GPU (left/right eye) via a `stereoOffset` geometry-shader uniform. No CPU double-render.

Slider at 0 = `eyeCount=1`, uniform writes skipped, identical to mono baseline. Zero overhead when unused.

**Core pieces:**
- `stereoOffset` uniform (GS register #5) in `shader_tiles.g.pica`
- Per-eye texture `SNES_MAIN_R` in VRAM Bank A (redirect via `gpu3dsApplyRenderState` — NOT a new `SGPU_TARGET_ID` because that bitfield would overflow 3 bits)
- Depth factors auto-derived from the emulator's own `DRAW_*` compositing values indexed by `PPU.BGMode`
- Per-priority OBJ depth via existing vertex-data priority bits (single-pass, GS handles it)
- Mode 7 perspective stereo via Y-based depth scaling in the GS
- Config bump: global 1.5 → 1.6, game 1.3 → 1.4

## Addressing your April 22 comment

> I tested stereo-v3-rebase-v1601 and it looks better than v2, but there are still several points that don't fully work for me yet.

Can you list the specific points you noticed? Given how much changed between v2 and this rebase, I'd rather fix what you actually saw than guess. Happy to do a dedicated hardware pass on any game/scene you call out.

## Known documented limitations

- **Edge-column clipping at high 3D slider.** Geometry shader applies offset without clamping; tiles at the 256-col edge can shift partially off the framebuffer. Inherent to stereoscopic parallax — M2's 3D Classics work around this by rendering extra off-screen columns (larger pipeline change). Mitigation: lower slider or per-layer gauge.
- **Sub-screen color math misalignment.** Sub is rendered mono while main is stereo-shifted. Games whose title screens use sub-screen color math for visual coloring can show washed colors (additive blend of misaligned main+sub saturates). In-game effects (transparency, water) are subtle enough to be acceptable. A per-eye sub-screen pass would fix this but break transparency in many other games.

## Commits

15, roughly ordered: infrastructure → feature → fixes → polish → docs.

```
19c0b13 feat(shader): add stereoOffset uniform to tile geometry shader
38d8d90 feat(gpu): stereo infrastructure — SNES_MAIN_R, uniform, right-eye redirect
b3dc42e feat(stereo): allocate right-eye texture and per-eye compositing
7bc4147 feat(stereo): per-eye draw loop with layer depth and Mode 7 perspective
f33c6cf feat(stereo): settings, config persistence, and menu UI
f79bf3e fix(stereo): menu rebuild on toggle + remove redundant game default
9033058 fix(stereo): backdrop depth offset + SNES_MAIN_R debug string
b14c189 docs(shader): document stereoOffset invariants in shader_tiles.g.pica
053abca feat(shader): stage pass-through GS for shader_screen (citro3d #56 workaround)
1d2851a fix(stereo): composite SNES_MAIN for right eye when menu stereo is disabled
d4614e7 fix(stereo): correct c_depth constant in tile vertex shader (1/32 -> 1/16)
b97b7b6 fix(stereo): apply depthFactor to BG layer base in the per-tile path
97798ab feat(stereo): per-layer Depth gauges are signed, 0 = Auto
a8396c7 docs(stereo): README + CHANGELOG for stereoscopic 3D + per-game depth tuning
f38df5f fix(stereo): code-review findings — Mode 7 sign, config bounds, doc accuracy
```

Happy to reorder or split into a stacked series if that reviews better.

## Updates since opening

Three doc-only commits pushed on top of the 15 above (head now at `27bffe4`):

- `d9ad7f1` `docs(shader)`: warn against per-tile-position scaling of stereo offset
- `2b2b704` `docs(stereo)`: note overscan zoom mitigates HDMA scroll edge artifact
- `27bffe4` `docs(stereo)`: broaden edge-artifact note to include Mode 7 perspective

Net code change vs the build behind the original 15 commits: zero. The CHANGELOG now documents two known edge-margin artifact families (HDMA per-scanline BG scroll on Super Metroid Maridia / Zelda ALttP weather, and Mode 7 perspective on Super Mario Kart / F-Zero) and recommends per-game crop / overscan zoom as the user-facing mitigation — same pattern you proposed in #55 for the top-line glitch.

Hardware re-validated on N3DS XL 2026-04-22 against the head at `27bffe4`.

Thanks again for the patience and the detailed feedback last time.

