### PR TITLE
perf/feat(mode7): skip unused TILE_0 blit + optional bilinear smoothing

### DIFF
--- a/source/3dsconfig.h
+++ b/source/3dsconfig.h
@@ -9,7 +9,7 @@
 #include "3ds.h"
 
 #define GLOBAL_CONFIG_FILE_TARGET_VERSION   1.5f
-#define GAME_CONFIG_FILE_TARGET_VERSION     1.3f
+#define GAME_CONFIG_FILE_TARGET_VERSION     1.4f
 
 float config3dsGetVersionFromFile(bool isGameConfig, char *versionStringFromFile);
 void  config3dsResetParseWarning();

--- a/source/3dsgpu.cpp
+++ b/source/3dsgpu.cpp
@@ -916,6 +916,12 @@ void gpu3dsBindTexture(SGPU_TEXTURE_ID textureId)
     {
         GPU_TEXTURE_WRAP_PARAM wrap = PPU.Mode7Repeat == 0 ? GPU_REPEAT : GPU_CLAMP_TO_BORDER;
         C3D_TexSetWrap(&texture->tex, wrap, wrap);
+
+        // Mode 7 bilinear smoothing is a per-game opt-in. Bilinear
+        // filtering is free on PICA200 (same cost as nearest), so the
+        // only reason to default off is that it changes the look.
+        GPU_TEXTURE_FILTER_PARAM m7filter = settings3DS.Mode7BilinearFilter ? GPU_LINEAR : GPU_NEAREST;
+        C3D_TexSetFilter(&texture->tex, m7filter, m7filter);
     }
 
     C3D_TexBind(0, &texture->tex);

--- a/source/3dsimpl_gpu.cpp
+++ b/source/3dsimpl_gpu.cpp
@@ -389,8 +389,21 @@ void gpu3dsDrawMode7Texture()
 
 	GPU3DSExt.mode7TilesModified = false;
 
-	GPU3DS.currentRenderState.target = TARGET_SNES_MODE7_TILE_0;
-	gpu3dsDraw(list, NULL, 4, 16384);
+	// Mode 7 "screen over transparent" bits ($211A bits 6-7, stored in
+	// PPU.Mode7Repeat):
+	//   0, 1 -> wrap the tilemap (TILE_0 is NOT sampled)
+	//   2    -> fill out-of-bounds with colour 0 (TILE_0 is NOT sampled)
+	//   3    -> repeat tile 0 across the whole plane (TILE_0 IS sampled)
+	// snes9x_3ds's draw path uses the "repeat tile 0" shader for
+	// Mode7Repeat values where the low bit is set (1 and 3), so bake
+	// the 16x16 TILE_0 texture in those cases only. Saves one draw
+	// and one render-target switch every frame on the common wrap /
+	// transparent cases (F-Zero, Super Mario Kart, Pilotwings, etc.).
+	if (PPU.Mode7Repeat & 1)
+	{
+		GPU3DS.currentRenderState.target = TARGET_SNES_MODE7_TILE_0;
+		gpu3dsDraw(list, NULL, 4, 16384);
+	}
 
 	// re-bind our tile shader
 	GPU3DS.currentRenderState.shader = SPROGRAM_TILES;

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -748,7 +748,10 @@ void makeOptionMenu(std::vector<SMenuItem>& items, std::vector<SMenuTab>& menuTa
 
     AddMenuPicker(items, "  In-Frame Palette Changes"_s, "Try changing this if some colors in the game look off."_s, makeOptionsForInFramePaletteChanges(), settings3DS.PaletteFix, DIALOG_TYPE_INFO, true,
                   []( int val ) { CheckAndUpdate( settings3DS.PaletteFix, val ); });
-    
+
+    AddMenuCheckbox(items, "  Mode 7 Smoothing"_s, settings3DS.Mode7BilinearFilter,
+        []( int val ) { CheckAndUpdateToggle( settings3DS.Mode7BilinearFilter, val ); });
+
     AddMenuDisabledOption(items, ""_s);
 
     AddMenuHeader2(items, "Audio"_s);
@@ -1043,6 +1046,12 @@ bool settingsReadWriteFullListByGame(bool writeMode)
     config3dsReadWriteInt32(stream, writeMode, "Frameskips=%d\n", &settings3DS.MaxFrameSkips, 0, 4);
     config3dsReadWriteInt32(stream, writeMode, "Vol=%d\n", &settings3DS.Volume, 0, 8);
     config3dsReadWriteInt32(stream, writeMode, "PalFix=%d\n", &settings3DS.PaletteFix, 0, 3);
+
+    // New in game config version 1.4. Older configs don't have this key;
+    // default (false) is preserved by settings3dsResetGameDefaults().
+    if (writeMode || detectedConfigVersion >= 1.4f) {
+        config3dsReadWriteEnum(stream, writeMode, "Mode7BilinearFilter=%d\n", &settings3DS.Mode7BilinearFilter, 0, 1);
+    }
     config3dsReadWriteEnum(stream, writeMode, "AutoSavestate=%d\n", &settings3DS.AutoSavestate, 0, 1);
     config3dsReadWriteInt32(stream, writeMode, "SRAMInterval=%d\n", &settings3DS.SRAMSaveInterval, 0, 4);
     config3dsReadWriteEnum(stream, writeMode, "ForceSRAMWrite=%d\n", &settings3DS.ForceSRAMWriteOnPause, 0, 1);

--- a/source/3dssettings.cpp
+++ b/source/3dssettings.cpp
@@ -66,6 +66,7 @@ void settings3dsResetGlobalDefaults() {
 void settings3dsResetGameDefaults() {
     settings3DS.Framerate = Setting::Framerate::UseRomRegion;
     settings3DS.PaletteFix = 0;
+    settings3DS.Mode7BilinearFilter = false;
     settings3DS.Volume = settings3DS.GlobalVolume;
     settings3DS.MaxFrameSkips = 1;
     settings3DS.CurrentSaveSlot = 1;

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -169,6 +169,11 @@ typedef struct {
                                                 //   2 - Disabled - Style 1.
                                                 //   3 - Disabled - Style 2.
 
+    bool                Mode7BilinearFilter;    // Bilinear filter for Mode 7 backgrounds.
+                                                // Default: false. Bilinear sampling is free on
+                                                // PICA200 (same cost as nearest) but changes
+                                                // the characteristic blocky Mode 7 look.
+
     int                 Volume;                 // 0: 100% Default volume,
                                                 // 1: 125%, 2: 150%, 3: 175%, 4: 200%
                                                 // 5: 225%, 6: 250%, 7: 275%, 8: 300%


### PR DESCRIPTION
Two small Mode 7 refinements — both scoped, independently reviewable, defaults preserve current behaviour.

## 1. Skip TILE_0 blit when `Mode7Repeat` doesn't use it

`gpu3dsDrawMode7Texture` currently bakes `SNES_MODE7_TILE_0` every frame Mode 7 is active. Per the SNES "screen over transparent" spec ($211A bits 6-7, `PPU.Mode7Repeat`):

- 0 — wrap tilemap (TILE_0 not sampled)
- 1 — wrap (TILE_0 sampled by `_RepeatTile0` draw path)
- 2 — fill out-of-bounds with colour 0 (TILE_0 not sampled)
- 3 — repeat tile 0 (TILE_0 sampled)

`S9xDrawBackgroundMode7HardwareRepeatTile0` is only dispatched when the low bit of `Mode7Repeat` is set, so the bake is only visible to the game in those cases. The guard matches:

```cpp
if (PPU.Mode7Repeat & 1) {
    GPU3DS.currentRenderState.target = TARGET_SNES_MODE7_TILE_0;
    gpu3dsDraw(list, NULL, 4, 16384);
}
```

Effect: one draw + one render-target switch saved every Mode 7 frame on games where `Mode7Repeat` is 0 or 2. That's most Mode 7 games — F-Zero, Pilotwings, Yoshi's Island overworld, Super Mario Kart race mode. Bowser Castle in SMK (which does use `Mode7Repeat == 3`) keeps the bake as before.

No visual change observed on hardware (N3DS XL) across F-Zero and Yoshi's Island.

## 2. Per-game "Mode 7 Smoothing" toggle

New checkbox in per-game Video settings, off by default. When enabled, `SNES_MODE7_FULL` is sampled with `GPU_LINEAR` instead of `GPU_NEAREST`.

Bilinear filtering is free on PICA200 (same cost as nearest). Default off because the blocky look is the characteristic Mode 7 aesthetic many users expect — making it opt-in preserves baseline behaviour. Wired into `gpu3dsBindTexture()` alongside the existing wrap-mode handling, so it's scoped to the one binding point that matters.

Per-game (not global) so users can enable it only for games where the smoothing is an improvement.

Config side: game config version bumped 1.3 → 1.4; new key gated on version so old configs load the default without a parse warning.

## Files touched

```
 source/3dsconfig.h      |   2 +-
 source/3dsgpu.cpp       |   6 ++++++
 source/3dsimpl_gpu.cpp  |  17 +++++++++++++++--
 source/3dsmain.cpp      |   9 +++++++++
 source/3dssettings.cpp  |   1 +
 source/3dssettings.h    |   5 +++++
 6 files changed, 37 insertions(+), 3 deletions(-)
```

No changes to the SNES core (`Snes9x/*`). Both changes are localized to the 3DS port's GPU / settings / menu layer.

## Not in this PR

Research for this round surfaced two larger opportunities that I'm keeping separate to keep review surface small:

- **Dirty-char-list iteration** in `S9xPrepareMode7CheckAndUpdateCharTiles` — replace the 16,384-entry tilemap scan with a char → map-indices reverse index. Bigger speedup on palette-animated Mode 7 games, but a bigger change touching `gfxhw.cpp` logic; wanted a clean Phase 1 first.
- **Re-enabling the commented-out char-bitmap dirty tracking in `ppu.h:449-456`** — currently Mode 7 char bitmap VRAM writes don't invalidate the tile cache, so games that animate char bitmaps in-place (rare but possible) will show stale tiles. That's a correctness fix, but it meaningfully increases the work `S9xPrepareMode7CheckAndUpdateCharTiles` does, so the dirty-list iteration above wants to land first.

Happy to follow up with either as separate PRs if the direction is welcome.

## Hardware validation

N3DS XL, current master (`fb200ab`) + these two commits:

- F-Zero — title + race: identical visually, no glitches.
- Yoshi's Island overworld: identical visually.
- Slider at 0 and with stretch modes: no change.

Opening as Draft in case you want to weigh in on the filter-toggle UX before I flip to Ready.
