### PR TITLE
perf(mode7): skip unused TILE_0 blit when Mode7Repeat doesn't use it

### DIFF
--- a/source/3dsimpl_gpu.cpp
+++ b/source/3dsimpl_gpu.cpp
@@ -389,8 +389,15 @@ void gpu3dsDrawMode7Texture()
 
 	GPU3DSExt.mode7TilesModified = false;
 
-	GPU3DS.currentRenderState.target = TARGET_SNES_MODE7_TILE_0;
-	gpu3dsDraw(list, NULL, 4, 16384);
+	// SNES_MODE7_TILE_0 is only sampled when Mode7Repeat is 3 ("repeat tile 0
+	// across the plane"). Modes 0 and 2 (wrap / fill with colour 0) don't
+	// sample it. Skipping the bake saves one draw + one render-target switch
+	// every Mode 7 frame on those modes.
+	if (PPU.Mode7Repeat == 3)
+	{
+		GPU3DS.currentRenderState.target = TARGET_SNES_MODE7_TILE_0;
+		gpu3dsDraw(list, NULL, 4, 16384);
+	}
 
 	// re-bind our tile shader
 	GPU3DS.currentRenderState.shader = SPROGRAM_TILES;

--- a/source/Snes9x/gfxhw.cpp
+++ b/source/Snes9x/gfxhw.cpp
@@ -2887,7 +2887,7 @@ void S9xRenderScreenHardware (bool8 sub)
 					S9xDrawBackgroundMode7Hardware(bg, sub, depth, alphaTestActive); \
 				} \
 
-			bool isTile0 = PPU.Mode7Repeat != 0 && PPU.Mode7Repeat != 2;
+			bool isTile0 = PPU.Mode7Repeat == 3;
             if (IPPU.Mode7EXTBGFlag) {
                 DRAW_M7BG(1, 2, 0, isTile0);
                 DRAW_M7BG(1, 8, 1, isTile0);


### PR DESCRIPTION
Splits the perf half of #62 per your 2026-04-25 review.

## Summary
SNES_MODE7_TILE_0 is only sampled when `PPU.Mode7Repeat == 3` ("repeat tile 0 across the plane"). Modes 0 and 2 (wrap / fill with colour 0) don't sample it. Skipping the bake saves one draw + one render-target switch every Mode 7 frame on those modes.

## Review feedback addressed (from #62)
- Condition is `PPU.Mode7Repeat == 3` (was `& 1`) at `3dsimpl_gpu.cpp:402`
- `isTile0` aligned to the same condition at `gfxhw.cpp:2890`
- Comment block at `3dsimpl_gpu.cpp:394` cleaned up: dropped Mode7Repeat==1 case, "low bit" wording, and the F-Zero/Mario Kart/Pilotwings game list; corrected "repeat tile 0 shader" misnaming

## Test plan
- [ ] HW test on N3DS XL with a Mode7Repeat==3 game (visible plane unaffected)
- [ ] HW test on a Mode7Repeat==0/2 game (no regression in BG2 bake usage)

Companion PR for the bilinear feature is incoming separately. Closes the perf half of #62.