### PR TITLE
feat(mode7): per-game Mode 7 bilinear smoothing toggle

### DIFF
--- a/source/3dsconfig.h
+++ b/source/3dsconfig.h
@@ -9,7 +9,7 @@
 #include "3ds.h"
 
 #define GLOBAL_CONFIG_FILE_TARGET_VERSION   1.6f
-#define GAME_CONFIG_FILE_TARGET_VERSION     1.3f
+#define GAME_CONFIG_FILE_TARGET_VERSION     1.4f
 
 float config3dsGetVersionFromFile(bool isGameConfig, char *versionStringFromFile);
 void  config3dsResetParseWarning();

--- a/source/3dsgpu.cpp
+++ b/source/3dsgpu.cpp
@@ -932,6 +932,9 @@ void gpu3dsBindTexture(SGPU_TEXTURE_ID textureId)
     {
         GPU_TEXTURE_WRAP_PARAM wrap = PPU.Mode7Repeat == 0 ? GPU_REPEAT : GPU_CLAMP_TO_BORDER;
         C3D_TexSetWrap(&texture->tex, wrap, wrap);
+
+        GPU_TEXTURE_FILTER_PARAM m7filter = settings3DS.Mode7BilinearFilter ? GPU_LINEAR : GPU_NEAREST;
+        C3D_TexSetFilter(&texture->tex, m7filter, m7filter);
     }
 
     C3D_TexBind(0, &texture->tex);

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -770,7 +770,10 @@ void makeOptionMenu(std::vector<SMenuItem>& items, std::vector<SMenuTab>& menuTa
 
     AddMenuPicker(items, "  In-Frame Palette Changes"_s, "Try changing this if some colors in the game look off."_s, makeOptionsForInFramePaletteChanges(), settings3DS.PaletteFix, DIALOG_TYPE_INFO, true,
                   []( int val ) { CheckAndUpdate( settings3DS.PaletteFix, val ); });
-    
+
+    AddMenuCheckbox(items, "  Mode 7 Smoothing"_s, settings3DS.Mode7BilinearFilter,
+        []( int val ) { CheckAndUpdateToggle( settings3DS.Mode7BilinearFilter, val ); });
+
     AddMenuDisabledOption(items, ""_s);
 
     AddMenuHeader2(items, "Audio"_s);
@@ -1065,6 +1068,12 @@ bool settingsReadWriteFullListByGame(bool writeMode)
     config3dsReadWriteInt32(stream, writeMode, "Frameskips=%d\n", &settings3DS.MaxFrameSkips, 0, 4);
     config3dsReadWriteInt32(stream, writeMode, "Vol=%d\n", &settings3DS.Volume, 0, 8);
     config3dsReadWriteInt32(stream, writeMode, "PalFix=%d\n", &settings3DS.PaletteFix, 0, 3);
+
+    // New in game-config version 1.4. Older configs lack the key; the
+    // default (false) is set by settings3dsResetGameDefaults().
+    if (writeMode || detectedConfigVersion >= 1.4f) {
+        config3dsReadWriteEnum(stream, writeMode, "Mode7BilinearFilter=%d\n", &settings3DS.Mode7BilinearFilter, 0, 1);
+    }
     config3dsReadWriteEnum(stream, writeMode, "AutoSavestate=%d\n", &settings3DS.AutoSavestate, 0, 1);
     config3dsReadWriteInt32(stream, writeMode, "SRAMInterval=%d\n", &settings3DS.SRAMSaveInterval, 0, 4);
     config3dsReadWriteEnum(stream, writeMode, "ForceSRAMWrite=%d\n", &settings3DS.ForceSRAMWriteOnPause, 0, 1);

--- a/source/3dssettings.cpp
+++ b/source/3dssettings.cpp
@@ -69,6 +69,7 @@ void settings3dsResetGlobalDefaults() {
 void settings3dsResetGameDefaults() {
     settings3DS.Framerate = Setting::Framerate::UseRomRegion;
     settings3DS.PaletteFix = 0;
+    settings3DS.Mode7BilinearFilter = false;
     settings3DS.Volume = settings3DS.GlobalVolume;
     settings3DS.MaxFrameSkips = 1;
     settings3DS.CurrentSaveSlot = 1;

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -175,6 +175,10 @@ typedef struct {
                                                 //   2 - Disabled - Style 1.
                                                 //   3 - Disabled - Style 2.
 
+    bool                Mode7BilinearFilter;    // Bilinear filter for the Mode 7 background
+                                                // texture. Default false; opt-in because it
+                                                // changes the characteristic Mode 7 look.
+
     int                 Volume;                 // 0: 100% Default volume,
                                                 // 1: 125%, 2: 150%, 3: 175%, 4: 200%
                                                 // 5: 225%, 6: 250%, 7: 275%, 8: 300%


### PR DESCRIPTION
Splits the feature half of #62 per your 2026-04-25 review.

## Summary
Adds a per-game `Mode7BilinearFilter` toggle for Mode 7 background texture filtering. Default off; opt-in because it changes the characteristic Mode 7 look. Bumps the game config version from 1.3 → 1.4 so the new setting is persisted.

## Review feedback addressed (from #62)
- Comment at `3dssettings.h:173` no longer claims "Free" — describes the toggle without the perf claim
- Setting placement matches the existing per-game config pattern; menu entry sits in the Video section

## Test plan
- [ ] HW test on N3DS XL: toggle ON in a Mode 7 game (F-Zero, Mario Kart) — visible smoothing change
- [ ] HW test toggle OFF — characteristic Mode 7 look returns
- [ ] Confirm setting persists across reload (game config 1.4 round-trip)

Companion perf PR is #67. Together these close #62.
