### PR TITLE
Improve in-frame palette change compatibility (HDMA)

### DIFF
--- a/source/3dsimpl_gpu.h
+++ b/source/3dsimpl_gpu.h
@@ -20,6 +20,13 @@
 #define MAX_TEXTURE_POSITIONS		16383
 #define MAX_HASH					(65536 * 16 / 8)
 
+#define HDMA_PALETTE_VARIANT_CACHE_SIZE 4096
+
+// Boundary between normal tile cache and HDMA variant pool.
+// Variant pool size must be >= hash size to avoid collision.
+// Boundary must be even (normal cache pairs slot p with alt-frame p^1).
+#define MAX_TEXTURE_HASH_POSITIONS ((MAX_TEXTURE_POSITIONS - HDMA_PALETTE_VARIANT_CACHE_SIZE) & ~1)
+
 typedef struct {
     s16 x, y;
 } SVector2i;
@@ -169,7 +176,7 @@ typedef struct
 typedef struct
 {
     u16             vramCacheHashToTexturePosition[MAX_HASH + 1]; // 262146 bytes
-    int             vramCacheTexturePositionToHash[MAX_TEXTURE_POSITIONS]; // 65532 bytes
+    int             vramCacheTexturePositionToHash[MAX_TEXTURE_HASH_POSITIONS]; // 4*MAX_TEXTURE_HASH_POSITIONS bytes
     
     SLayerList      layerList;
 

--- a/source/3dsimpl_tilecache.cpp
+++ b/source/3dsimpl_tilecache.cpp
@@ -17,7 +17,7 @@ void cache3dsInit()
     // gives the texturePos of 0, but gets overwritten by other tiles
     //
     GPU3DSExt.vramCacheTexturePositionToHash[0] = 0;
-    for (int i = 1; i < MAX_TEXTURE_POSITIONS; i++)
+    for (int i = 1; i < MAX_TEXTURE_HASH_POSITIONS; i++)
         GPU3DSExt.vramCacheTexturePositionToHash[i] = MAX_HASH;
     GPU3DSExt.newCacheTexturePosition = 2;
 }

--- a/source/3dsimpl_tilecache.h
+++ b/source/3dsimpl_tilecache.h
@@ -35,7 +35,7 @@ inline int cache3dsGetTexturePositionFast(int tileAddr, int pal)
         GPU3DSExt.vramCacheTexturePositionToHash[pos] = hash;
 
         GPU3DSExt.newCacheTexturePosition += 2;
-        if (GPU3DSExt.newCacheTexturePosition >= MAX_TEXTURE_POSITIONS)
+        if (GPU3DSExt.newCacheTexturePosition >= MAX_TEXTURE_HASH_POSITIONS)
             GPU3DSExt.newCacheTexturePosition = 2;
 
         // Force this tile to re-decode. This fixes the tile corruption

--- a/source/Snes9x/dma.cpp
+++ b/source/Snes9x/dma.cpp
@@ -1138,6 +1138,7 @@ uint8 S9xDoHDMA (uint8 byte)
     int d = 0;
 
 	CPU.InDMA = TRUE;
+	IPPU.InHDMA = TRUE;
 	CPU.Cycles+=ONE_CYCLE*3;
 	//S9xUpdateAPUTimer();
     for (uint8 mask = 1; mask; mask <<= 1, p++, d++)
@@ -1362,6 +1363,7 @@ uint8 S9xDoHDMA (uint8 byte)
 		}
 	}
 
+	IPPU.InHDMA = FALSE;
 	CPU.InDMA=FALSE;
     return (byte);
 }

--- a/source/Snes9x/gfx.cpp
+++ b/source/Snes9x/gfx.cpp
@@ -611,11 +611,8 @@ void S9xUpdatePalettes()
 
 			if (finalColor != IPPU.ScreenColors [cgaddr])
 			{
+				S9xUpdatePaletteHashesForCgaddr(cgaddr, IPPU.ScreenColors[cgaddr], finalColor);
 				IPPU.ScreenColors [cgaddr] = finalColor;
-				GFX.PaletteFrame256[0] ++;
-				GFX.PaletteFrame[cgaddr >> 4] ++;
-				if (cgaddr < 128)
-					GFX.PaletteFrame4BG[cgaddr >> 5][(cgaddr & 0x1f) >> 2] ++;
 			}
 		}
 		IPPU.ColorsChanged = false;

--- a/source/Snes9x/gfx.cpp
+++ b/source/Snes9x/gfx.cpp
@@ -633,6 +633,13 @@ void S9xStartScreenRefresh ()
 	}*/
 
 	IPPU.PreviousLine = IPPU.CurrentLine = 0;
+	IPPU.HDMAPalette4BGMask[0] = 0;
+	IPPU.HDMAPalette4BGMask[1] = 0;
+	IPPU.HDMAPalette4BGMask[2] = 0;
+	IPPU.HDMAPalette4BGMask[3] = 0;
+	IPPU.HDMAPalette16Mask = 0;
+	IPPU.HDMAAnyCGRAMTouched = FALSE;
+	IPPU.InHDMA = FALSE;
 
     if (IPPU.RenderThisFrame)
     {

--- a/source/Snes9x/gfx.h
+++ b/source/Snes9x/gfx.h
@@ -268,6 +268,38 @@ void S9xUpdatePalettes();
 // port.
 extern struct SGFX GFX;
 
+// Scramble one (slot, color) pair into a 32-bit value so each slot+color
+// mixes to its own distinct number (per-window variants: 256 / 16 / 4 colors).
+static inline uint32 S9xPaletteHashContrib256(int cgaddr, uint16 color)
+{
+    return ((uint32)(cgaddr & 0xFF) * 0x9E3779B1u + 1u) * (uint32)color;
+}
+static inline uint32 S9xPaletteHashContrib16(int cgaddr, uint16 color)
+{
+    return ((uint32)(cgaddr & 0xF) * 0xC2B2AE3Du + 1u) * (uint32)color;
+}
+static inline uint32 S9xPaletteHashContrib4(int cgaddr, uint16 color)
+{
+    return ((uint32)(cgaddr & 0x3) * 0x7FEB352Du + 1u) * (uint32)color;
+}
+
+// PaletteFrame* are XOR-based stamps of the palette's contents: the same
+// colors always give the same stamp. This lets the tile cache reuse a tile
+// when an HDMA palette flips back to a value it already had this frame
+// (e.g. road-stripe scanline palettes).
+static inline void S9xUpdatePaletteHashesForCgaddr(int cgaddr, uint16 oldColor, uint16 newColor)
+{
+    GFX.PaletteFrame256[0] ^= S9xPaletteHashContrib256(cgaddr, oldColor);
+    GFX.PaletteFrame256[0] ^= S9xPaletteHashContrib256(cgaddr, newColor);
+    GFX.PaletteFrame[cgaddr >> 4] ^= S9xPaletteHashContrib16(cgaddr, oldColor);
+    GFX.PaletteFrame[cgaddr >> 4] ^= S9xPaletteHashContrib16(cgaddr, newColor);
+    if (cgaddr < 128)
+    {
+        GFX.PaletteFrame4BG[cgaddr >> 5][(cgaddr & 0x1F) >> 2] ^= S9xPaletteHashContrib4(cgaddr, oldColor);
+        GFX.PaletteFrame4BG[cgaddr >> 5][(cgaddr & 0x1F) >> 2] ^= S9xPaletteHashContrib4(cgaddr, newColor);
+    }
+}
+
 bool8 S9xGraphicsInit ();
 void S9xGraphicsDeinit();
 bool8 S9xInitUpdate (void);

--- a/source/Snes9x/gfxhw.cpp
+++ b/source/Snes9x/gfxhw.cpp
@@ -1991,7 +1991,7 @@ void S9xDrawBackgroundMosaicHardware(
     int OffsetShift = (tileSize == 16) ? 4 : 3;
     int QuotSplit   = (hires || tileSize == 16) ? 63 : 31;
 
-    int YStart = (int)GFX.StartY;
+    int YStart = (int)LayerRender.startY[bg];
     int YEnd   = (int)GFX.EndY + 1;
     int MosaicOffset = YStart % S;
     int FirstBlockH = S - MosaicOffset;

--- a/source/Snes9x/gfxhw.cpp
+++ b/source/Snes9x/gfxhw.cpp
@@ -1022,7 +1022,7 @@ inline void __attribute__((always_inline)) S9xDrawOffsetBackgroundHardwarePriori
 
 	// Optimized version of the offset per tile renderer
 	//
-	for (uint32 OY = GFX.StartY; OY <= GFX.EndY; )
+	for (uint32 OY = LayerRender.startY[bg]; OY <= GFX.EndY; )
     {
 		// Do a check to find out how many scanlines
 		// that the BGnVOFS, BGnHOFS, BG2VOFS, BG2HOS
@@ -1564,7 +1564,7 @@ inline void __attribute__((always_inline)) S9xDrawBackgroundHardwarePriority0Inl
 		OffsetShift = 3;
     }
 
-    for (uint32 Y = GFX.StartY; Y <= GFX.EndY; Y += Lines)
+    for (uint32 Y = LayerRender.startY[bg]; Y <= GFX.EndY; Y += Lines)
     {
 		uint32 VOffset = LineData [Y].BG[bg].VOffset;
 		uint32 HOffset = LineData [Y].BG[bg].HOffset;
@@ -2224,7 +2224,7 @@ inline void __attribute__((always_inline)) S9xDrawHiresBackgroundHardwarePriorit
 
     int endy = IPPU.Interlace ? 1 + (GFX.EndY << 1) : GFX.EndY;
 	
-    for (int Y = IPPU.Interlace ? GFX.StartY << 1 : GFX.StartY; Y <= endy; Y += Lines)
+    for (int Y = IPPU.Interlace ? LayerRender.startY[bg] << 1 : LayerRender.startY[bg]; Y <= endy; Y += Lines)
     {
 		int y = IPPU.Interlace ? (Y >> 1) : Y;
 		uint32 VOffset = LineData [y].BG[bg].VOffset;
@@ -2613,7 +2613,7 @@ void S9xDrawOBJSHardware (bool8 sub, int depth = 0, int priority = 0)
 	GFX.PixSize = 1;
 	
 	// Wonder what is the best value for this to get the optimal performance? 
-	if (PPU.PriorityDrawFromSprite >= 0 && GFX.EndY - GFX.StartY >= 16)
+	if (PPU.PriorityDrawFromSprite >= 0 && GFX.EndY - LayerRender.startY[LAYER_OBJ] >= 16)
 	{
 		//printf ("Fast OBJ draw %d\n", PPU.PriorityDrawFromSprite);
 		// Clear all heights
@@ -2628,7 +2628,7 @@ void S9xDrawOBJSHardware (bool8 sub, int depth = 0, int priority = 0)
 			OBJList[i++].Height = 0;
 			OBJList[i++].Height = 0;
 		}
-		for(uint32 Y=GFX.StartY; Y<=GFX.EndY; Y++)
+		for(uint32 Y=LayerRender.startY[LAYER_OBJ]; Y<=GFX.EndY; Y++)
 		{
 			for (int I = GFX.OBJLines[Y].OBJCount - 1; I >= 0; I --)
 			{
@@ -2718,7 +2718,7 @@ void S9xDrawOBJSHardware (bool8 sub, int depth = 0, int priority = 0)
 	{
 		int priorityDepthOffset = depth + 768; // Pre-calculate (1 * 3 * 256 + depth)
 
-		for(uint32 Y=GFX.StartY, Offset=Y*GFX.PPL; Y<=GFX.EndY; Y++, Offset+=GFX.PPL)
+		for(uint32 Y=LayerRender.startY[LAYER_OBJ], Offset=Y*GFX.PPL; Y<=GFX.EndY; Y++, Offset+=GFX.PPL)
 		{
 			const auto& objLine = GFX.OBJLines[Y];
 
@@ -3041,7 +3041,7 @@ void S9xDrawBackgroundMode7Hardware(int bg, bool8 sub, int depth, int alphaTestA
 		return;
 	}
 
-	for (int Y = (int)GFX.StartY; Y <= (int)GFX.EndY; Y++)
+	for (int Y = (int)LayerRender.startY[bg]; Y <= (int)GFX.EndY; Y++)
 	{
 		struct SLineMatrixData *p = &LineMatrixData [Y];
 
@@ -3103,7 +3103,7 @@ void S9xDrawBackgroundMode7HardwareRepeatTile0(int bg, bool8 sub, int depth)
 {
 	bool verticesUpdated = false;
 	
-	for (int Y = (int)GFX.StartY; Y <= (int)GFX.EndY; Y++)
+	for (int Y = (int)LayerRender.startY[bg]; Y <= (int)GFX.EndY; Y++)
 	{
 		struct SLineMatrixData *p = &LineMatrixData [Y];
 
@@ -3205,41 +3205,41 @@ void S9xRenderScreenHardware (bool8 sub)
     }
 
 	#define DRAW_4COLOR_BG_INLINE(bg, p, d0, d1) \
-		if (bgEnabled[bg]) \
+		if (bgEnabled[bg] && LayerRender.shouldRenderThisSegment[bg]) \
 			S9xDrawBackgroundHardwarePriority0Inline_4Color (PPU.BGMode, bg, sub, d0 * 256 + bgAlpha[bg], d1 * 256 + bgAlpha[bg]); \
 
 	#define DRAW_16COLOR_BG_INLINE(bg, p, d0, d1) \
-		if (bgEnabled[bg]) \
+		if (bgEnabled[bg] && LayerRender.shouldRenderThisSegment[bg]) \
 			S9xDrawBackgroundHardwarePriority0Inline_16Color (PPU.BGMode, bg, sub, d0 * 256 + bgAlpha[bg], d1 * 256 + bgAlpha[bg]); \
 
 	#define DRAW_256COLOR_BG_INLINE(bg, p, d0, d1) \
-		if (bgEnabled[bg]) \
+		if (bgEnabled[bg] && LayerRender.shouldRenderThisSegment[bg]) \
 			S9xDrawBackgroundHardwarePriority0Inline_256Color (PPU.BGMode, bg, sub, d0 * 256 + bgAlpha[bg], d1 * 256 + bgAlpha[bg]); \
 
 	#define DRAW_4COLOR_OFFSET_BG_INLINE(bg, p, d0, d1) \
-		if (bgEnabled[bg]) \
+		if (bgEnabled[bg] && LayerRender.shouldRenderThisSegment[bg]) \
 			S9xDrawOffsetBackgroundHardwarePriority0Inline_4Color (PPU.BGMode, bg, sub, d0 * 256 + bgAlpha[bg], d1 * 256 + bgAlpha[bg]); \
 
 	#define DRAW_16COLOR_OFFSET_BG_INLINE(bg, p, d0, d1) \
-		if (bgEnabled[bg]) \
+		if (bgEnabled[bg] && LayerRender.shouldRenderThisSegment[bg]) \
 			S9xDrawOffsetBackgroundHardwarePriority0Inline_16Color (PPU.BGMode, bg, sub, d0 * 256 + bgAlpha[bg], d1 * 256 + bgAlpha[bg]); \
 
 	#define DRAW_256COLOR_OFFSET_BG_INLINE(bg, p, d0, d1) \
-		if (bgEnabled[bg]) \
+		if (bgEnabled[bg] && LayerRender.shouldRenderThisSegment[bg]) \
 			S9xDrawOffsetBackgroundHardwarePriority0Inline_256Color (PPU.BGMode, bg, sub, d0 * 256 + bgAlpha[bg], d1 * 256 + bgAlpha[bg]); \
 
 	#define DRAW_4COLOR_HIRES_BG_INLINE(bg, p, d0, d1) \
-		if (bgEnabled[bg]) \
+		if (bgEnabled[bg] && LayerRender.shouldRenderThisSegment[bg]) \
 			S9xDrawHiresBackgroundHardwarePriority0Inline_4Color (PPU.BGMode, bg, sub, d0 * 256 + bgAlpha[bg], d1 * 256 + bgAlpha[bg]); \
 
 	#define DRAW_16COLOR_HIRES_BG_INLINE(bg, p, d0, d1) \
-		if (bgEnabled[bg]) \
+		if (bgEnabled[bg] && LayerRender.shouldRenderThisSegment[bg]) \
 			S9xDrawHiresBackgroundHardwarePriority0Inline_16Color (PPU.BGMode, bg, sub, d0 * 256 + bgAlpha[bg], d1 * 256 + bgAlpha[bg]); \
 
 	S9xUpdateBackdropSections(!isMode5or6 && sub, sub, bgAlpha[LAYER_BACKDROP]);
 	renderState.textureEnv = TEX_ENV_REPLACE_TEXTURE0_COLOR_ALPHA;
 
-	if (bgEnabled[LAYER_OBJ]) {
+	if (bgEnabled[LAYER_OBJ] && LayerRender.shouldRenderThisSegment[LAYER_OBJ]) {
 		S9xDrawOBJSHardware(sub, bgAlpha[LAYER_OBJ], 0);
 	}
 
@@ -3288,7 +3288,7 @@ void S9xRenderScreenHardware (bool8 sub)
 
         case 7:
 			#define DRAW_M7BG(bg, d, alphaTestActive, tile0) \
-				if (bgEnabled[bg]) \
+				if (bgEnabled[bg] && LayerRender.shouldRenderThisSegment[bg]) \
 				{ \
 					int depth = bgAlpha[bg] + d*256; \
 					if (tile0) \
@@ -3650,9 +3650,93 @@ bool S9xTrimBlackScanlines(VerticalSections *brightnessSections)
 }
 
 
+// Computes the conservative static palette-16 footprint for a BG:
+// all windows the BG's dispatch params can address.
+static uint16 S9xComputeBgPalette16UsedMask(int bg)
+{
+    int paletteShift;
+    int paletteMask = 7;
+    int startPalette = 0;
+    bool directColour = false;
+
+    switch (PPU.BGMode)
+    {
+        case 0:
+            paletteShift = 2;
+            startPalette = bg << 5;
+            break;
+        case 1:
+            if (bg == 2) { paletteShift = 2; }
+            else if (bg < 2) { paletteShift = 4; }
+            else return 0;
+            break;
+        case 2:
+            if (bg < 2) { paletteShift = 4; }
+            else return 0;
+            break;
+        case 3:
+            if (bg == 0) {
+                paletteShift = 0;
+                directColour = (GFX.r2130 & 1) != 0;
+            } else if (bg == 1) {
+                paletteShift = 4;
+            } else return 0;
+            break;
+        case 4:
+            if (bg == 0) {
+                paletteShift = 0;
+                directColour = (GFX.r2130 & 1) != 0;
+            } else if (bg == 1) {
+                paletteShift = 2;
+            } else return 0;
+            break;
+        case 5:
+            if (bg == 0) { paletteShift = 4; }
+            else if (bg == 1) { paletteShift = 2; }
+            else return 0;
+            break;
+        case 6:
+            if (bg == 0) { paletteShift = 4; }
+            else return 0;
+            break;
+        case 7:
+        default:
+            // Mode 7 / unknown: conservative — always render.
+            return 0xFFFFu;
+    }
+
+    if (directColour || paletteShift == 0)
+        return 0xFFFFu;
+
+    uint16 mask = 0;
+    if (paletteShift == 4)
+    {
+        const int base = (startPalette >> 4) & 0xF;
+        for (int p = 0; p <= paletteMask; p++)
+            mask |= (uint16)(1u << ((base + p) & 0xF));
+    }
+    else // paletteShift == 2
+    {
+        for (int p = 0; p <= paletteMask; p++)
+            mask |= (uint16)(1u << (((startPalette + (p << 2)) >> 4) & 0xF));
+    }
+    return mask;
+}
+
+
 //-----------------------------------------------------------
 // Updates the screen using the 3D hardware.
 //-----------------------------------------------------------
+
+void S9xFlushDeferredLayers ()
+{
+    for (int i = 0; i < 5; i++) {
+        if (LayerRender.startY[i] < (uint32)IPPU.CurrentLine) {
+            S9xUpdateScreenHardware();
+            return;
+        }
+    }
+}
 
 void S9xUpdateScreenHardware ()
 {	
@@ -3683,6 +3767,35 @@ void S9xUpdateScreenHardware ()
     if (isLastSection)
 		GFX.EndY = PPU.ScreenHeight - 1;
 
+	const uint32 preTrimStartY = GFX.StartY;
+	const uint32 preTrimEndY = GFX.EndY;
+
+	// Per-frame reset of layer cursors
+	if (LayerRender.resetFrame != ICPU.Frame) {
+		for (int i = 0; i < 5; i++)
+			LayerRender.startY[i] = 0;
+		LayerRender.resetFrame = ICPU.Frame;
+	}
+
+	// Per-layer deferral gate. Only REGISTER_2122 sets allowDefer, so every
+	// other flush force-renders all layers -- deferred ranges catch up before
+	// non-palette PPU state (e.g. BG scroll $210D..$2114) takes effect.
+	const bool forceAllLayers = !LayerRender.allowDefer || isLastSection;
+	const uint16 changedMask = LayerRender.changedPalette16Mask;
+	bool anyLayerDeferred = false;
+	for (int i = 0; i < 5; i++) {
+		if (forceAllLayers) {
+			LayerRender.shouldRenderThisSegment[i] = true;
+		} else {
+			const uint16 used = (i == LAYER_OBJ) ? 0xff00u : S9xComputeBgPalette16UsedMask(i);
+			LayerRender.shouldRenderThisSegment[i] = (changedMask & used) != 0;
+		}
+
+    	if (LayerRender.startY[i] < preTrimStartY)
+        	anyLayerDeferred = true;
+	}
+	LayerRender.changedPalette16Mask = 0;
+
     if (IPPU.OBJChanged)
 		S9xSetupOBJ ();
 
@@ -3692,12 +3805,9 @@ void S9xUpdateScreenHardware ()
 	PPU.RangeTimeOver |= GFX.OBJLines[GFX.EndY].RTOFlags;
 
 
-	// Preserve pre-trim scanline range for WindowLR overlap.
-	// S9xTrimBlackScanlines may shrink GFX.StartY/EndY for rendering.
-	const uint32 windowLRRangeStartY = GFX.StartY;
-	const uint32 windowLRRangeEndY = GFX.EndY;
-	
-	bool RenderThisSection = S9xTrimBlackScanlines(&IPPU.BrightnessSections);
+	// anyLayerDeferred forces a render even if S9xTrimBlackScanlines would
+	// veto this segment, so trim-skipped ranges still flush deferred catch-up.
+	bool RenderThisSection = anyLayerDeferred ? true : S9xTrimBlackScanlines(&IPPU.BrightnessSections);
 
 	// set render state to default
 	renderState = GPU3DS.currentRenderState;
@@ -3746,9 +3856,9 @@ void S9xUpdateScreenHardware ()
 		for (int i = 0; i < windowLRSections->Count; i++) {
 			VerticalSection *section = &windowLRSections->Section[i];
 
-			if (section->EndY < (int16)windowLRRangeStartY)
+			if (section->EndY < (int16)preTrimStartY)
 				continue;
-			if (section->StartY > (int16)windowLRRangeEndY)
+			if (section->StartY > (int16)preTrimEndY)
 				break;
 
 			WindowingEnabled[section->StartY] = IPPU.WindowingEnabled;
@@ -3783,6 +3893,11 @@ void S9xUpdateScreenHardware ()
 
 		S9xCommitClipToBlackAndColorMathSections();
 	}
-		
+
+	for (int i = 0; i < 5; i++) {
+		if (LayerRender.shouldRenderThisSegment[i])
+			LayerRender.startY[i] = preTrimEndY + 1;
+	}
+
 	t3dsStopTimer(TIMER_S9X_UPDATE_SCREEN);
 }

--- a/source/Snes9x/gfxhw.cpp
+++ b/source/Snes9x/gfxhw.cpp
@@ -696,7 +696,7 @@ inline void __attribute__((always_inline)) S9xDrawBGFullTileHardwareInline (
 	bool variantPossible,
 	int prio, int depth0, int depth1,
 	int32 snesTile, int32 screenX, int32 screenY,
-	int32 startLine, int32 height)
+	int32 startLine, int32 height, bool stretchedTy)
 {
     uint32 TileAddr = BG.TileAddress + ((snesTile & 0x3ff) << tileShift);
 
@@ -788,7 +788,7 @@ inline void __attribute__((always_inline)) S9xDrawBGFullTileHardwareInline (
 	int tx0 = 0;
 	int ty0 = startLine >> 3;
 	int tx1 = 8;
-	int ty1 = ty0 + height;
+	int ty1 = stretchedTy ? (ty0 + 1) : (ty0 + height); // // +1: nearest-neighbour floors all rows to ty0
 
 	gpu3dsAddTileVertexes(
 		x0, y0, x1, y1,
@@ -805,7 +805,7 @@ inline void __attribute__((always_inline)) S9xDrawHiresBGFullTileHardwareInline 
 	bool variantPossible,
 	int prio, int depth0, int depth1,
 	int32 snesTile, int32 screenX, int32 screenY,
-	int32 startLine, int32 height)
+	int32 startLine, int32 height, bool stretchedTy)
 {
     uint32 TileAddr = BG.TileAddress + ((snesTile & 0x3ff) << tileShift);
 
@@ -896,9 +896,9 @@ inline void __attribute__((always_inline)) S9xDrawHiresBGFullTileHardwareInline 
 	int tx0 = 0;
 	int ty0 = startLine >> 3;
 	int tx1 = 7;
-	int ty1 = ty0 + height;
+	int ty1 = stretchedTy ? (ty0 + 1) : (ty0 + height);
 
-	if (IPPU.Interlace)
+	if (IPPU.Interlace && !stretchedTy)
 		ty1 = ty1 + height - 1;
 
 	gpu3dsAddTileVertexes(
@@ -1256,7 +1256,7 @@ inline void __attribute__((always_inline)) S9xDrawOffsetBackgroundHardwarePriori
 						variantPossible,
 						tpriority, depth0, depth1,
 						modifiedTile, sX, Y,
-						VirtAlign, Lines);
+						VirtAlign, Lines, false);
 				}
 
 				// Proceed to the tile below, in the same column.
@@ -1571,10 +1571,25 @@ inline void __attribute__((always_inline)) S9xDrawBackgroundHardwarePriority0Inl
 
 		int VirtAlign = (Y + VOffset) & 7;
 
-		for (Lines = 1; Lines < 8 - VirtAlign; Lines++)
-			if ((VOffset != LineData [Y + Lines].BG[bg].VOffset) ||
-				(HOffset != LineData [Y + Lines].BG[bg].HOffset))
-				break;
+		// scroll-cancellation case: VOffset varies per scanline but (VOffset+Y) stays constant,
+		// so every row shows the same source tile-row. Draw that row once stretched down the
+		// run (stretchedTy=true) and lift the 8-line cap so the whole run can be one tile.
+		bool stretchedTy = false;
+		for (Lines = 1; ; Lines++)
+		{
+			if (Y + Lines > GFX.EndY) break;
+			if (!stretchedTy && Lines >= 8 - VirtAlign) break;
+			uint32 nextV = LineData [Y + Lines].BG[bg].VOffset;
+			uint32 nextH = LineData [Y + Lines].BG[bg].HOffset;
+			if (HOffset != nextH) break;
+			if (VOffset == nextV) {
+				if (stretchedTy) break;
+				continue;
+			}
+			if (VOffset + Y != nextV + (Y + Lines)) break;
+			if (Lines > 1 && !stretchedTy) break;
+			stretchedTy = true;
+		}
 
 		if (Y + Lines > GFX.EndY)
 			Lines = GFX.EndY + 1 - Y;
@@ -1683,7 +1698,7 @@ inline void __attribute__((always_inline)) S9xDrawBackgroundHardwarePriority0Inl
 						tileSize, tileShift, paletteShift, paletteMask, startPalette, directColourMode,
 						variantPossible,
 						tpriority, depth0, depth1,
-						modifiedTile, sX, sY, VirtAlign, Lines);
+						modifiedTile, sX, sY, VirtAlign, Lines, stretchedTy);
 				}
 
 				if (tileSize == 8)
@@ -2230,12 +2245,28 @@ inline void __attribute__((always_inline)) S9xDrawHiresBackgroundHardwarePriorit
 		uint32 VOffset = LineData [y].BG[bg].VOffset;
 		uint32 HOffset = LineData [y].BG[bg].HOffset;
 		int VirtAlign = (Y + VOffset) & 7;
-		
-		for (Lines = 1; Lines < 8 - VirtAlign; Lines++)
-			if ((VOffset != LineData [y + Lines].BG[bg].VOffset) ||
-				(HOffset != LineData [y + Lines].BG[bg].HOffset))
-				break;
-			
+
+		// Scroll-cancellation extension is gated off in interlace mode.
+		// Each logical scanline serves two screen-Y values there, 
+		// so the per-screen-pixel pattern can't map to a single source row.
+		bool stretchedTy = false;
+		for (Lines = 1; ; Lines++)
+		{
+			if (Y + Lines > endy) break;
+			if (!stretchedTy && Lines >= 8 - VirtAlign) break;
+			uint32 nextV = LineData [y + Lines].BG[bg].VOffset;
+			uint32 nextH = LineData [y + Lines].BG[bg].HOffset;
+			if (HOffset != nextH) break;
+			if (VOffset == nextV) {
+				if (stretchedTy) break;
+				continue;
+			}
+			if (IPPU.Interlace) break;
+			if (VOffset + y != nextV + (y + Lines)) break;
+			if (Lines > 1 && !stretchedTy) break;
+			stretchedTy = true;
+		}
+
 		HOffset <<= 1;
 		if (Y + Lines > endy)
 			Lines = endy + 1 - Y;
@@ -2337,7 +2368,7 @@ inline void __attribute__((always_inline)) S9xDrawHiresBackgroundHardwarePriorit
 					tileSize, tileShift, paletteShift, paletteMask, startPalette, directColourMode,
 					variantPossible,
 					tpriority, depth0, depth1,
-					modifiedTile, sX, sY, VirtAlign, actualLines);
+					modifiedTile, sX, sY, VirtAlign, actualLines, stretchedTy);
 				
 				t += Quot & 1;
 				if (Quot == 63)

--- a/source/Snes9x/gfxhw.cpp
+++ b/source/Snes9x/gfxhw.cpp
@@ -73,8 +73,160 @@ int16 layerVerticesCount[5];
 SGPURenderState renderState;
 
 DrawableVerticalSection drawableVerticalSections[4][241];
-u16 drawableSectionCount[4] = { 0, 0, 0, 0 }; 
+u16 drawableSectionCount[4] = { 0, 0, 0, 0 };
 
+
+#define HDMA_PALETTE_VARIANT_CACHE_PROBES 16
+
+typedef struct
+{
+	uint32 tilePalKey;
+	uint32 paletteFrame;
+	uint16 texturePos;
+	uint16 generation;
+} SHDMAPaletteVariantCacheEntry;
+
+// In-frame BG palette variant cache for HDMA CGRAM updates.
+// This handles per-scanline palette changes without 2-slot collisions.
+static SHDMAPaletteVariantCacheEntry hdmaPaletteVariantCache[HDMA_PALETTE_VARIANT_CACHE_SIZE];
+
+static uint32 hdmaPaletteVariantCacheFrameId = 0xffffffff;
+static uint16 hdmaPaletteVariantTexturePos = MAX_TEXTURE_HASH_POSITIONS;
+static uint16 hdmaPaletteVariantCacheGeneration = 1;
+
+inline void __attribute__((always_inline)) S9xResetHdmaPaletteVariantCache()
+{
+	if (hdmaPaletteVariantCacheFrameId == ICPU.Frame)
+		return;
+
+	hdmaPaletteVariantCacheGeneration++;
+	if (hdmaPaletteVariantCacheGeneration == 0)
+	{
+		// uint16 wrapped (~65k frames): memset once so gen 0 entries don't alias gen 1.
+		memset(hdmaPaletteVariantCache, 0, sizeof(hdmaPaletteVariantCache));
+		hdmaPaletteVariantCacheGeneration = 1;
+	}
+	hdmaPaletteVariantTexturePos = MAX_TEXTURE_HASH_POSITIONS;
+	hdmaPaletteVariantCacheFrameId = ICPU.Frame;
+}
+
+inline uint16 __attribute__((always_inline)) S9xGetNextHdmaPaletteVariantTexturePos()
+{
+	uint16 texturePos = hdmaPaletteVariantTexturePos;
+	hdmaPaletteVariantTexturePos++;
+	if (hdmaPaletteVariantTexturePos >= MAX_TEXTURE_POSITIONS)
+		hdmaPaletteVariantTexturePos = MAX_TEXTURE_HASH_POSITIONS;
+	return texturePos;
+}
+
+// BG-level precheck: 
+// check if the variant gate can possibly fire for ANY tile in this BG draw call
+inline bool __attribute__((always_inline)) S9xVariantPossibleForBg(bool directColourMode, int paletteShift, int paletteMask, int startPalette)
+{
+	if (SNESGameFixes.PaletteCommitLine != -2 || directColourMode || !IPPU.HDMAAnyCGRAMTouched)
+		return false;
+
+	if (paletteShift == 2)
+	{
+		const int paletteBank = (startPalette >> 5) & 0x3;
+		// paletteMask covers the sub-palette bits a tile can address;
+		// if no HDMA-touched sub-palette in this bank overlaps, skip.
+		return (IPPU.HDMAPalette4BGMask[paletteBank] & paletteMask) != 0;
+	}
+
+	if (paletteShift == 4)
+	{
+		// pal ranges 0..15 so palette16Index covers all 16 windows;
+		// any non-zero HDMA mask means some tile could trigger.
+		return IPPU.HDMAPalette16Mask != 0;
+	}
+
+	return paletteShift == 0;
+}
+
+
+inline bool __attribute__((always_inline)) S9xUseHdmaPaletteVariantPath(int paletteShift, int startPalette, uint8 pal)
+{
+	if (paletteShift == 2)
+	{
+		const int paletteBank = (startPalette >> 5) & 0x3;
+		return (IPPU.HDMAPalette4BGMask[paletteBank] & (1 << (pal & 0xF))) != 0;
+	}
+
+	if (paletteShift == 4)
+	{
+		const int palette16Index = ((startPalette >> 4) + (pal & 0xF)) & 0xF;
+		return (IPPU.HDMAPalette16Mask & (1 << palette16Index)) != 0;
+	}
+
+	return true;
+}
+
+inline uint8 __attribute__((always_inline)) S9xGetHdmaPaletteVariantKey(int paletteShift, int startPalette, uint8 pal)
+{
+	if (paletteShift == 2)
+		return (((startPalette >> 5) & 0x3) << 4) | (pal & 0xF);
+	if (paletteShift == 4)
+		return 0x40 | (pal & 0xF);
+	return 0x50;
+}
+
+inline int __attribute__((always_inline)) S9xGetHdmaPaletteVariantTexturePos(
+	uint32 tileAddrDiv8,
+	uint8 tilePalVariantKey,
+	int paletteShift,
+	uint32 paletteFrameValue,
+	uint8 *pCache,
+	uint16 *screenColors)
+{
+	S9xResetHdmaPaletteVariantCache();
+
+	// tile + palette -> palette state -> bucket number
+	//
+	// tile's address into the upper bits (13 bits), palette-variant key into the low 7 bits;
+	// XOR id with palette content stamp;
+	// shift-XOR, multiply by an odd constant, shift-XOR again
+	const uint32 tilePalKey = ((tileAddrDiv8 & 0x1FFF) << 7) | (tilePalVariantKey & 0x7F);
+	uint32 hash = tilePalKey ^ paletteFrameValue;
+	hash ^= hash >> 16;
+	hash *= 0x7feb352d;
+	hash ^= hash >> 15;
+
+	// Linear probing: start at the hashed bucket and walk forward,
+	// looking for our entry or the first free slot. 
+	// The 16-probe cap is a heuristic tuned against HDMA-heavy test games, where most exit in ~1 probe
+	int insertIndex = -1;
+	for (int probe = 0; probe < HDMA_PALETTE_VARIANT_CACHE_PROBES; probe++)
+	{
+		const int idx = (hash + probe) & (HDMA_PALETTE_VARIANT_CACHE_SIZE - 1);
+		SHDMAPaletteVariantCacheEntry *entry = &hdmaPaletteVariantCache[idx];
+
+		// slot is empty -> decode
+		if (entry->generation != hdmaPaletteVariantCacheGeneration)
+		{
+			insertIndex = idx;
+			break;
+		}
+
+		// cache hit
+		if (entry->tilePalKey == tilePalKey && entry->paletteFrame == paletteFrameValue)
+			return entry->texturePos;
+	}
+
+	uint16 texturePos = S9xGetNextHdmaPaletteVariantTexturePos();
+	cache3dsCacheSnesTileToTexturePosition(pCache, screenColors, texturePos);
+
+	if (insertIndex >= 0)
+	{
+		SHDMAPaletteVariantCacheEntry *entry = &hdmaPaletteVariantCache[insertIndex];
+		entry->tilePalKey = tilePalKey;
+		entry->paletteFrame = paletteFrameValue;
+		entry->texturePos = texturePos;
+		entry->generation = hdmaPaletteVariantCacheGeneration;
+	}
+
+	return texturePos;
+}
 
 inline void __attribute__((always_inline)) S9xAddVerticalSection(VERTICAL_SECTION_ID id, u16 idx, u16 y0, u16 y1, DrawableSectionValue value, DrawableSectionRenderState state) {
 	DrawableVerticalSection *section = &drawableVerticalSections[id][idx];
@@ -541,8 +693,9 @@ inline void __attribute__((always_inline)) S9xCommitMode7LayerSection(bool reuse
 //-------------------------------------------------------------------
 inline void __attribute__((always_inline)) S9xDrawBGFullTileHardwareInline (
     int tileSize, int tileShift, int paletteShift, int paletteMask, int startPalette, bool directColourMode,
-	int prio, int depth0, int depth1, 
-	int32 snesTile, int32 screenX, int32 screenY, 
+	bool variantPossible,
+	int prio, int depth0, int depth1,
+	int32 snesTile, int32 screenX, int32 screenY,
 	int32 startLine, int32 height)
 {
     uint32 TileAddr = BG.TileAddress + ((snesTile & 0x3ff) << tileShift);
@@ -607,13 +760,23 @@ inline void __attribute__((always_inline)) S9xDrawBGFullTileHardwareInline (
 		screenColors = &IPPU.ScreenColors[(pal << paletteShift) + startPalette];
 	}
 
-	if (GFX.VRAMPaletteFrame[tileAddrDiv8][pal] != paletteFrame[pal])
+	if (variantPossible && S9xUseHdmaPaletteVariantPath(paletteShift, startPalette, pal))
+    {
+		texturePos = S9xGetHdmaPaletteVariantTexturePos(
+			tileAddrDiv8,
+			S9xGetHdmaPaletteVariantKey(paletteShift, startPalette, pal),
+			paletteShift,
+			paletteFrame[pal],
+			pCache,
+			screenColors);
+    }
+    else if (GFX.VRAMPaletteFrame[tileAddrDiv8][pal] != paletteFrame[pal])
     {
         texturePos = cacheGetSwapTexturePositionForAltFrameFast(tileAddrDiv8, pal);
         GFX.VRAMPaletteFrame[tileAddrDiv8][pal] = paletteFrame[pal];
         cache3dsCacheSnesTileToTexturePosition(pCache, screenColors, texturePos);
     }
-	
+
 
 	// Render tile
 	//
@@ -639,6 +802,7 @@ inline void __attribute__((always_inline)) S9xDrawBGFullTileHardwareInline (
 //-------------------------------------------------------------------
 inline void __attribute__((always_inline)) S9xDrawHiresBGFullTileHardwareInline (
     int tileSize, int tileShift, int paletteShift, int paletteMask, int startPalette, bool directColourMode,
+	bool variantPossible,
 	int prio, int depth0, int depth1,
 	int32 snesTile, int32 screenX, int32 screenY,
 	int32 startLine, int32 height)
@@ -706,13 +870,23 @@ inline void __attribute__((always_inline)) S9xDrawHiresBGFullTileHardwareInline 
 		screenColors = &IPPU.ScreenColors[(pal << paletteShift) + startPalette];
 	}
 
-	if (GFX.VRAMPaletteFrame[tileAddrDiv8][pal] != paletteFrame[pal])
+	if (variantPossible && S9xUseHdmaPaletteVariantPath(paletteShift, startPalette, pal))
+    {
+		texturePos = S9xGetHdmaPaletteVariantTexturePos(
+			tileAddrDiv8,
+			S9xGetHdmaPaletteVariantKey(paletteShift, startPalette, pal),
+			paletteShift,
+			paletteFrame[pal],
+			pCache,
+			screenColors);
+    }
+    else if (GFX.VRAMPaletteFrame[tileAddrDiv8][pal] != paletteFrame[pal])
     {
         texturePos = cacheGetSwapTexturePositionForAltFrameFast(tileAddrDiv8, pal);
         GFX.VRAMPaletteFrame[tileAddrDiv8][pal] = paletteFrame[pal];
         cache3dsCacheSnesTileToTexturePosition(pCache, screenColors, texturePos);
     }
-	
+
 	int x0 = screenX >> 1;
 	int y0 = screenY + (prio == 0 ? depth0 : depth1);
 	
@@ -743,6 +917,7 @@ inline void __attribute__((always_inline)) S9xDrawOffsetBackgroundHardwarePriori
     int tileSize, int tileShift, int bitShift, int paletteShift, int paletteMask, int startPalette, bool directColourMode,
 	uint32 BGMode, uint32 bg, bool sub, int depth0, int depth1)
 {
+    const bool variantPossible = S9xVariantPossibleForBg(directColourMode, paletteShift, paletteMask, startPalette);
     uint32 Tile;
     uint16 *SC0;
     uint16 *SC1;
@@ -1078,8 +1253,9 @@ inline void __attribute__((always_inline)) S9xDrawOffsetBackgroundHardwarePriori
 
 					S9xDrawBGFullTileHardwareInline(
 						tileSize, tileShift, paletteShift, paletteMask, startPalette, directColourMode,
+						variantPossible,
 						tpriority, depth0, depth1,
-						modifiedTile, sX, Y, 
+						modifiedTile, sX, Y,
 						VirtAlign, Lines);
 				}
 
@@ -1298,6 +1474,7 @@ inline void __attribute__((always_inline)) S9xDrawBackgroundHardwarePriority0Inl
     int tileSize, int tileShift, int bitShift, int paletteShift, int paletteMask, int startPalette, bool directColourMode,
     uint32 BGMode, uint32 bg, bool sub, int depth0, int depth1)
 {
+    const bool variantPossible = S9xVariantPossibleForBg(directColourMode, paletteShift, paletteMask, startPalette);
     GFX.PixSize = 1;
 
 	//printf ("BG%d Y=%d-%d W1:%d-%d W2:%d-%d\n", bg, GFX.StartY, GFX.EndY, PPU.Window1Left, PPU.Window1Right, PPU.Window2Left, PPU.Window2Right);
@@ -1504,6 +1681,7 @@ inline void __attribute__((always_inline)) S9xDrawBackgroundHardwarePriority0Inl
 
 					S9xDrawBGFullTileHardwareInline(
 						tileSize, tileShift, paletteShift, paletteMask, startPalette, directColourMode,
+						variantPossible,
 						tpriority, depth0, depth1,
 						modifiedTile, sX, sY, VirtAlign, Lines);
 				}
@@ -1959,6 +2137,7 @@ inline void __attribute__((always_inline)) S9xDrawHiresBackgroundHardwarePriorit
     int tileSize, int tileShift, int bitShift, int paletteShift, int paletteMask, int startPalette, bool directColourMode,
     uint32 BGMode, uint32 bg, bool sub, int depth0, int depth1)
 {
+    const bool variantPossible = S9xVariantPossibleForBg(directColourMode, paletteShift, paletteMask, startPalette);
     GFX.PixSize = 1;
 
  	// Note: We draw subscreens first, then the main screen.
@@ -2156,6 +2335,7 @@ inline void __attribute__((always_inline)) S9xDrawHiresBackgroundHardwarePriorit
 
 				S9xDrawHiresBGFullTileHardwareInline(
 					tileSize, tileShift, paletteShift, paletteMask, startPalette, directColourMode,
+					variantPossible,
 					tpriority, depth0, depth1,
 					modifiedTile, sX, sY, VirtAlign, actualLines);
 				

--- a/source/Snes9x/gfxhw.cpp
+++ b/source/Snes9x/gfxhw.cpp
@@ -129,9 +129,9 @@ inline bool __attribute__((always_inline)) S9xVariantPossibleForBg(bool directCo
 	if (paletteShift == 2)
 	{
 		const int paletteBank = (startPalette >> 5) & 0x3;
-		// paletteMask covers the sub-palette bits a tile can address;
-		// if no HDMA-touched sub-palette in this bank overlaps, skip.
-		return (IPPU.HDMAPalette4BGMask[paletteBank] & paletteMask) != 0;
+		// Conservative BG-level precheck: any HDMA-touched sub-palette in this bank runs the path.
+		// S9xUseHdmaPaletteVariantPath then checks the tile's actual sub-palette
+		return IPPU.HDMAPalette4BGMask[paletteBank] != 0;
 	}
 
 	if (paletteShift == 4)

--- a/source/Snes9x/ppu.cpp
+++ b/source/Snes9x/ppu.cpp
@@ -32,6 +32,14 @@ uint8 in_bit=0;
 
 extern uint8 *HDMAMemPointers [8];
 
+struct LayerRenderState LayerRender = {
+    /* allowDefer */                false,
+    /* changedPalette16Mask */      0,
+    /* startY */                    { 0, 0, 0, 0, 0 },
+    /* shouldRenderThisSegment */   { true, true, true, true, true },
+    /* resetFrame */                0xFFFFFFFFu,
+};
+
 
 static inline void S9xLatchCounters (bool force)
 {

--- a/source/Snes9x/ppu.cpp
+++ b/source/Snes9x/ppu.cpp
@@ -2592,6 +2592,8 @@ void S9xResetPPU ()
 	IPPU.ColorsChanged = TRUE;
 	IPPU.HDMA = 0;
 	IPPU.HDMAStarted = FALSE;
+	IPPU.InHDMA = FALSE;
+	IPPU.HDMAAnyCGRAMTouched = FALSE;
 	IPPU.MaxBrightness = 0;
 	IPPU.LatchedBlanking = 0;
 	IPPU.OBJChanged = TRUE;
@@ -2615,6 +2617,11 @@ void S9xResetPPU ()
 	IPPU.Mode7CharDirtyFlagCount = 1;
 	IPPU.Mode7Prepared = 0;
 	IPPU.Mode7EXTBGFlag = -1;
+	IPPU.HDMAPalette4BGMask[0] = 0;
+	IPPU.HDMAPalette4BGMask[1] = 0;
+	IPPU.HDMAPalette4BGMask[2] = 0;
+	IPPU.HDMAPalette4BGMask[3] = 0;
+	IPPU.HDMAPalette16Mask = 0;
 
 	for (int i = 0; i < 16; i++)
 	{
@@ -2816,6 +2823,8 @@ void S9xSoftResetPPU ()
 	IPPU.ColorsChanged = TRUE;
 	IPPU.HDMA = 0;
 	IPPU.HDMAStarted = FALSE;
+	IPPU.InHDMA = FALSE;
+	IPPU.HDMAAnyCGRAMTouched = FALSE;
 	IPPU.MaxBrightness = 0;
 	IPPU.LatchedBlanking = 0;
 	IPPU.OBJChanged = TRUE;
@@ -2839,6 +2848,11 @@ void S9xSoftResetPPU ()
 	IPPU.Mode7CharDirtyFlagCount = 1;
 	IPPU.Mode7Prepared = 0;
 	IPPU.Mode7EXTBGFlag = -1;
+	IPPU.HDMAPalette4BGMask[0] = 0;
+	IPPU.HDMAPalette4BGMask[1] = 0;
+	IPPU.HDMAPalette4BGMask[2] = 0;
+	IPPU.HDMAPalette4BGMask[3] = 0;
+	IPPU.HDMAPalette16Mask = 0;
 
 	for (int i = 0; i < 16; i++)
 	{

--- a/source/Snes9x/ppu.h
+++ b/source/Snes9x/ppu.h
@@ -42,6 +42,8 @@ struct InternalPPU {
     bool8  ColorsChanged;
     uint8  HDMA;
     bool8  HDMAStarted;
+    bool8  InHDMA;
+    bool8  HDMAAnyCGRAMTouched;
     uint8  MaxBrightness;
     bool8  LatchedBlanking;
     bool8  OBJChanged;
@@ -101,6 +103,11 @@ struct InternalPPU {
     //
     uint16 Mode7ScreenColors[256];
     uint16 Mode7ScreenColors128[256];
+
+    // Per-frame bitmasks for 4-color BG palette subsets updated via HDMA.
+    // [bank] uses bit [pal] where bank = startPalette >> 5 and pal is 0-15.
+    uint16 HDMAPalette4BGMask[4];
+    uint16 HDMAPalette16Mask;
 
     // Added for register change optimization.
     // Helps in reducing number of FLUSH_REDRAWs per frame.
@@ -797,6 +804,14 @@ STATIC inline void REGISTER_2122(uint8 Byte)
     if (newScreenColor != oldScreenColor)
     {
         S9xUpdatePaletteHashesForCgaddr(cgaddr, oldScreenColor, newScreenColor);
+
+        if (IPPU.InHDMA)
+        {
+            IPPU.HDMAAnyCGRAMTouched = TRUE;
+            IPPU.HDMAPalette16Mask |= (1 << (cgaddr >> 4));
+            if (cgaddr < 128)
+                IPPU.HDMAPalette4BGMask[cgaddr >> 5] |= (1 << ((cgaddr & 0x1F) >> 2));
+        }
     }
 
     if (cgaddr == 0)

--- a/source/Snes9x/ppu.h
+++ b/source/Snes9x/ppu.h
@@ -261,6 +261,7 @@ struct SDMA {
 };
 
 START_EXTERN_C
+void S9xFlushDeferredLayers();
 void S9xUpdateScreen ();
 void S9xInitializeVerticalSections();
 void S9xResetPPU ();
@@ -307,7 +308,16 @@ END_EXTERN_C
 
 
 //#define DEBUG_FLUSH_REDRAW(a,b)   if (IPPU.PreviousLine != IPPU.CurrentLine && IPPU.RenderThisFrame) { printf ("FD: %04x <- %02x @ Y=%d\n", a, b, IPPU.CurrentLine); } else { printf ("    %04x <- %02x @ Y=%d\n", a, b, IPPU.CurrentLine); }
-#define DEBUG_FLUSH_REDRAW(a,b)    
+#define DEBUG_FLUSH_REDRAW(a,b)
+
+struct LayerRenderState {
+    bool   allowDefer;                  // true only during a REGISTER_2122 FLUSH
+    uint16 changedPalette16Mask;        // palette-16 windows mutated since last FLUSH
+    uint32 startY[5];                   // per-layer next-line-to-render cursor
+    bool   shouldRenderThisSegment[5];  // gate decision this segment
+    uint32 resetFrame;                  // last frame the cursors were reset
+};
+extern struct LayerRenderState LayerRender;
 
 STATIC inline uint8 REGISTER_4212()
 {
@@ -325,12 +335,15 @@ STATIC inline uint8 REGISTER_4212()
 
 STATIC inline void FLUSH_REDRAW ()
 {
-    if (IPPU.PreviousLine != IPPU.CurrentLine && IPPU.RenderThisFrame)
+    if (IPPU.RenderThisFrame)
     {
-        //if (GFX.Use3DSHardware)
+        if (IPPU.PreviousLine != IPPU.CurrentLine) {
             S9xUpdateScreenHardware();
-        //else
-	    //    S9xUpdateScreenSoftware ();
+        } else if (!LayerRender.allowDefer) {
+            // Same-scanline non-$2122 flush: drain any still-deferred layers
+            // before a silent register update corrupts their catch-up state.
+            S9xFlushDeferredLayers();
+        }
     }
 }
 
@@ -752,7 +765,12 @@ STATIC inline void REGISTER_2122(uint8 Byte)
             changed = true;
             
             if (SNESGameFixes.PaletteCommitLine == -2 && cgaddr != 0)
+            {
+                LayerRender.changedPalette16Mask |= (uint16)(1u << (cgaddr >> 4));
+                LayerRender.allowDefer = true;
                 FLUSH_REDRAW();
+                LayerRender.allowDefer = false;
+            }
         }
         PPU.CGADD++;
     }
@@ -764,7 +782,12 @@ STATIC inline void REGISTER_2122(uint8 Byte)
             changed = true;
             
             if (SNESGameFixes.PaletteCommitLine == -2 && cgaddr != 0)
+            {
+                LayerRender.changedPalette16Mask |= (uint16)(1u << (cgaddr >> 4));
+                LayerRender.allowDefer = true;
                 FLUSH_REDRAW();
+                LayerRender.allowDefer = false;
+            }
         }
     }
 

--- a/source/Snes9x/ppu.h
+++ b/source/Snes9x/ppu.h
@@ -782,21 +782,22 @@ STATIC inline void REGISTER_2122(uint8 Byte)
         return;
     }
 
+    const uint16 oldScreenColor = IPPU.ScreenColors[cgaddr];
     const uint16 color = *cgdata;
     IPPU.Red[cgaddr] = IPPU.XB[color & 0x1F];
     IPPU.Green[cgaddr] = IPPU.XB[(color >> 5) & 0x1F];
     IPPU.Blue[cgaddr] = IPPU.XB[(color >> 10) & 0x1F];
     IPPU.ScreenColors[cgaddr] = BUILD_PIXEL(
-        IPPU.Red[cgaddr], 
-        IPPU.Green[cgaddr], 
+        IPPU.Red[cgaddr],
+        IPPU.Green[cgaddr],
         IPPU.Blue[cgaddr]
     );
+    const uint16 newScreenColor = IPPU.ScreenColors[cgaddr];
 
-    GFX.PaletteFrame256[0]++;
-    GFX.PaletteFrame[cgaddr >> 4]++;
-    
-    if (cgaddr < 128)
-        GFX.PaletteFrame4BG[cgaddr >> 5][(cgaddr & 0x1F) >> 2]++;
+    if (newScreenColor != oldScreenColor)
+    {
+        S9xUpdatePaletteHashesForCgaddr(cgaddr, oldScreenColor, newScreenColor);
+    }
 
     if (cgaddr == 0)
         S9xUpdateVerticalSectionValue(&IPPU.BackdropColorSections, IPPU.ScreenColors[0]);


### PR DESCRIPTION
This adds a per-frame variant cache for the HDMA path - a shared pool of up to ~4096 tile+palette versions per frame, allocated on demand.
The normal tile cache keeps only two decoded versions of a tile. That's fine for normal rendering, but a per-scanline palette change can make one tile need many colour versions in a single frame, so those draws reused a stale version and showed wrong colours / flickering. HDMA palette changes now use the variant cache instead; normal tiles still use the two-slot cache.
Probably not a complete fix for every in-frame palette case, but a clear compatibility improvement across several games that use per-scanline HDMA palette effects (e.g. Top Gear 2).
The variant path and deferral only run under PaletteCommitLine == -2 ("Enabled" menu setting for In-Frame Palette Changes).