### PR TITLE
Add enhanced resolution setting

### DIFF
--- a/source/3dsconfig.h
+++ b/source/3dsconfig.h
@@ -9,7 +9,7 @@
 #include "3ds.h"
 
 #define GLOBAL_CONFIG_FILE_TARGET_VERSION   1.6f
-#define GAME_CONFIG_FILE_TARGET_VERSION     1.4f
+#define GAME_CONFIG_FILE_TARGET_VERSION     1.5f
 
 float config3dsGetVersionFromFile(bool isGameConfig, char *versionStringFromFile);
 void  config3dsResetParseWarning();

--- a/source/3dsgpu.cpp
+++ b/source/3dsgpu.cpp
@@ -32,6 +32,21 @@ static bool isReal3DS() {
     return true;
 }
 
+static SGPU_TOP_MODE gpu3dsGetTopMode()
+{
+    if (settings3DS.GameScreen != GFX_TOP)
+        return TOP_MODE_2D;
+
+    if (settings3DS.EnhancedResolution && gpu3dsIsWideAvailable())
+        return TOP_MODE_WIDE;
+
+    if (!settings3DS.Disable3DSlider && gpu3dsIs3DAvailable())
+        return TOP_MODE_3D;
+
+    return TOP_MODE_2D;
+}
+
+
 //---------------------------------------------------------
 // Returns the inter-ocular distance in pixels based on
 // the 3D slider position. Returns 0 when slider is off.
@@ -64,15 +79,6 @@ bool gpu3dsIs3DAvailable()
 bool gpu3dsIsWideAvailable()
 {
     return GPU3DS.isReal3DS && GPU3DS.model != CFG_MODEL_2DS;
-}
-
-bool gpu3dsIs3DEnabled()
-{
-    return
-        !settings3DS.Disable3DSlider
-        && settings3DS.GameScreen == GFX_TOP
-        && !gfxIsWide()
-        && gfxIs3D();
 }
 
 void gpu3dsEnableDepthTest()
@@ -411,17 +417,27 @@ void gpu3dsFrameEnd(u8 flags)
     t3dsStopTimer(TIMER_FLUSH);
 }
 
-bool gpu3dsSetWideMode(bool wide)
+bool gpu3dsSetTopMode()
 {
-    if (wide && (settings3DS.GameScreen != GFX_TOP || !gpu3dsIsWideAvailable()))
-        return false;
+    GPU3DS.topMode = gpu3dsGetTopMode();
+    bool changed = false;
 
-    if (gfxIsWide() == wide)
-        return false;
+    bool isWideMode = (GPU3DS.topMode == TOP_MODE_WIDE);
+    if (gfxIsWide() != isWideMode) {
+        gfxSetWide(isWideMode);
+        GPU3DS.screenTargets[SCREEN_TARGET_LEFT]->frameBuf.height = isWideMode ? SCREEN_TOP_WIDTH * 2 : SCREEN_TOP_WIDTH;
+        changed = true;
+    }
 
-    gfxSetWide(wide);
-    GPU3DS.screenTargets[SCREEN_TARGET_LEFT]->frameBuf.height = wide ? SCREEN_TOP_WIDTH * 2 : SCREEN_TOP_WIDTH;
-    return true;
+    if (!isWideMode) {
+        bool is3DMode = (GPU3DS.topMode == TOP_MODE_3D);
+        if (gfxIs3D() != is3DMode) {
+            gfxSet3D(is3DMode);
+            changed = true;
+        }
+    }
+
+    return changed;
 }
 
 bool gpu3dsClearScreen(gfxScreen_t screen, bool isTopStereo) {

--- a/source/3dsgpu.cpp
+++ b/source/3dsgpu.cpp
@@ -37,7 +37,7 @@ static SGPU_TOP_MODE gpu3dsGetTopMode()
     if (settings3DS.GameScreen != GFX_TOP)
         return TOP_MODE_2D;
 
-    if (settings3DS.EnhancedResolution && gpu3dsIsWideAvailable())
+    if (settings3DS.EnhancedResolution == Setting::EnhancedResolution::Wide && gpu3dsIsWideAvailable())
         return TOP_MODE_WIDE;
 
     if (!settings3DS.Disable3DSlider && gpu3dsIs3DAvailable())

--- a/source/3dsgpu.cpp
+++ b/source/3dsgpu.cpp
@@ -486,6 +486,19 @@ bool gpu3dsInitialize()
     C3D_RenderTargetSetOutput(GPU3DS.screenTargets[SCREEN_TARGET_LEFT], GFX_TOP, GFX_LEFT, DISPLAY_TRANSFER_FLAGS);
 
     GPU3DS.screenTargets[SCREEN_TARGET_RIGHT] = C3D_RenderTargetCreate(SCREEN_HEIGHT, SCREEN_TOP_WIDTH, colorBufFmt, -1);
+    // Save ~281KB of VRAM (240x400 RGB8):
+    // 3D mode and wide mode never run together, so the right eye can reuse the second half
+    // of LEFT's 800px buffer (which only wide mode uses) instead of getting its own.
+    // Free RIGHT's buffer and clear ownsColor so it isn't freed twice on delete
+    {
+        C3D_RenderTarget *right = GPU3DS.screenTargets[SCREEN_TARGET_RIGHT];
+        if (right->ownsColor && right->frameBuf.colorBuf) {
+            vramFree(right->frameBuf.colorBuf);
+        }
+        right->ownsColor = false;
+        u32 offset = C3D_CalcColorBufSize(SCREEN_HEIGHT, SCREEN_TOP_WIDTH, colorBufFmt);
+        right->frameBuf.colorBuf = (u8 *)GPU3DS.screenTargets[SCREEN_TARGET_LEFT]->frameBuf.colorBuf + offset;
+    }
     C3D_RenderTargetSetOutput(GPU3DS.screenTargets[SCREEN_TARGET_RIGHT], GFX_TOP, GFX_RIGHT, DISPLAY_TRANSFER_FLAGS);
 
     GPU3DS.screenTargets[SCREEN_TARGET_BOTTOM] = C3D_RenderTargetCreate(SCREEN_HEIGHT, SCREEN_BOTTOM_WIDTH, colorBufFmt, -1);

--- a/source/3dsgpu.cpp
+++ b/source/3dsgpu.cpp
@@ -63,7 +63,7 @@ bool gpu3dsIs3DAvailable()
 
 bool gpu3dsIsWideAvailable()
 {
-    return GPU3DS.model != CFG_MODEL_2DS;
+    return GPU3DS.isReal3DS && GPU3DS.model != CFG_MODEL_2DS;
 }
 
 bool gpu3dsIs3DEnabled()
@@ -71,6 +71,7 @@ bool gpu3dsIs3DEnabled()
     return
         !settings3DS.Disable3DSlider
         && settings3DS.GameScreen == GFX_TOP
+        && !gfxIsWide()
         && gfxIs3D();
 }
 

--- a/source/3dsgpu.cpp
+++ b/source/3dsgpu.cpp
@@ -61,6 +61,11 @@ bool gpu3dsIs3DAvailable()
         && GPU3DS.model != CFG_MODEL_N2DSXL;
 }
 
+bool gpu3dsIsWideAvailable()
+{
+    return GPU3DS.model != CFG_MODEL_2DS;
+}
+
 bool gpu3dsIs3DEnabled()
 {
     return
@@ -405,6 +410,19 @@ void gpu3dsFrameEnd(u8 flags)
     t3dsStopTimer(TIMER_FLUSH);
 }
 
+bool gpu3dsSetWideMode(bool wide)
+{
+    if (wide && (settings3DS.GameScreen != GFX_TOP || !gpu3dsIsWideAvailable()))
+        return false;
+
+    if (gfxIsWide() == wide)
+        return false;
+
+    gfxSetWide(wide);
+    GPU3DS.screenTargets[SCREEN_TARGET_LEFT]->frameBuf.height = wide ? SCREEN_TOP_WIDTH * 2 : SCREEN_TOP_WIDTH;
+    return true;
+}
+
 bool gpu3dsClearScreen(gfxScreen_t screen, bool isTopStereo) {
 	SCREEN_TARGET targetId = screen == GFX_TOP ? SCREEN_TARGET_LEFT : SCREEN_TARGET_BOTTOM;
 
@@ -444,7 +462,10 @@ bool gpu3dsInitialize()
     GPU_COLORBUF colorBufFmt = (GPU_COLORBUF)gpu3dsGetTransferFmt((GPU_TEXCOLOR)DISPLAY_TRANSFER_FMT);
 
     // no depth buffer needed for screen targets
-    GPU3DS.screenTargets[SCREEN_TARGET_LEFT] = C3D_RenderTargetCreate(SCREEN_HEIGHT, SCREEN_TOP_WIDTH, colorBufFmt, -1);
+    // Allocate the top-left target at the full 800px wide-mode height
+    GPU3DS.screenTargets[SCREEN_TARGET_LEFT] = C3D_RenderTargetCreate(SCREEN_HEIGHT, SCREEN_TOP_WIDTH * 2, colorBufFmt, -1);
+    // initial viewport height is 400 (non-wide)
+    GPU3DS.screenTargets[SCREEN_TARGET_LEFT]->frameBuf.height = SCREEN_TOP_WIDTH;
     C3D_RenderTargetSetOutput(GPU3DS.screenTargets[SCREEN_TARGET_LEFT], GFX_TOP, GFX_LEFT, DISPLAY_TRANSFER_FLAGS);
 
     GPU3DS.screenTargets[SCREEN_TARGET_RIGHT] = C3D_RenderTargetCreate(SCREEN_HEIGHT, SCREEN_TOP_WIDTH, colorBufFmt, -1);

--- a/source/3dsgpu.h
+++ b/source/3dsgpu.h
@@ -155,6 +155,12 @@ typedef enum {
     SGPU_STATE_UNSET,
 } SGPU_STATE;
 
+typedef enum {
+    TOP_MODE_2D   = 0,
+    TOP_MODE_3D   = 1,
+    TOP_MODE_WIDE = 2,
+} SGPU_TOP_MODE;
+
 typedef enum
 {
     VBO_SCENE_RECT,
@@ -277,6 +283,7 @@ typedef struct
 
     bool                        isReal3DS;
     CFG_SystemModel             model;
+    SGPU_TOP_MODE               topMode;
     gfx3dSide_t                 activeSide;
     bool                        gameScreenBufferDesync;
 } SGPU3DS;
@@ -431,14 +438,13 @@ static inline void gpu3dsSetAttributeBuffers(SVertexList *list)
 void gpu3dsDraw(SVertexList *list, const void* indices, int count, int from = -1);
 bool gpu3dsFrameBegin(u8 flags = 0, bool ingame = false, bool isSecondScreen = false);
 void gpu3dsFrameEnd(u8 flags = 0);
-bool gpu3dsSetWideMode(bool wide);
 bool gpu3dsClearScreen(gfxScreen_t screen, bool isTopStereo = false);
 
 float gpu3dsGetIOD();
 float gpu3dsGetIODBase();
 bool gpu3dsIs3DAvailable();
 bool gpu3dsIsWideAvailable();
-bool gpu3dsIs3DEnabled();
+bool gpu3dsSetTopMode(); // Returns true if the applied gfx state changed
 
 
 #endif

--- a/source/3dsgpu.h
+++ b/source/3dsgpu.h
@@ -431,11 +431,13 @@ static inline void gpu3dsSetAttributeBuffers(SVertexList *list)
 void gpu3dsDraw(SVertexList *list, const void* indices, int count, int from = -1);
 bool gpu3dsFrameBegin(u8 flags = 0, bool ingame = false, bool isSecondScreen = false);
 void gpu3dsFrameEnd(u8 flags = 0);
+bool gpu3dsSetWideMode(bool wide);
 bool gpu3dsClearScreen(gfxScreen_t screen, bool isTopStereo = false);
 
 float gpu3dsGetIOD();
 float gpu3dsGetIODBase();
 bool gpu3dsIs3DAvailable();
+bool gpu3dsIsWideAvailable();
 bool gpu3dsIs3DEnabled();
 
 

--- a/source/3dsimpl.cpp
+++ b/source/3dsimpl.cpp
@@ -745,7 +745,7 @@ void impl3dsSceneRender(bool firstFrame, bool paused) {
         gameScreenViewport.sy1 = gameScreenViewport.sy0 + gameScreenViewport.cHeight;
         gameScreenViewport.tx0 = 0.0f;
         gameScreenViewport.ty0 = 0.0f;
-        gameScreenViewport.tx1 = static_cast<float>(SNES_WIDTH);
+        gameScreenViewport.tx1 = static_cast<float>(GPU3DSExt.renderWidth);
         gameScreenViewport.ty1 = static_cast<float>(PPU.ScreenHeight);
 
         GPU3DS.activeSide = GFX_LEFT;
@@ -806,7 +806,7 @@ void impl3dsSceneRender(bool firstFrame, bool paused) {
     gameScreenViewport.sy1 = gameScreenViewport.sy0 + gameScreenViewport.cHeight;
     gameScreenViewport.tx0 = 0.0f;
     gameScreenViewport.ty0 = static_cast<float>(cropTopSource);
-    gameScreenViewport.tx1 = static_cast<float>(SNES_WIDTH);
+    gameScreenViewport.tx1 = static_cast<float>(GPU3DSExt.renderWidth);
     gameScreenViewport.ty1 = static_cast<float>(PPU.ScreenHeight - cropBottomSource);
 
 	bool isFullScreen = gameScreenViewport.sWidth >= settings3DS.GameScreenWidth && gameScreenViewport.cHeight >= SCREEN_HEIGHT;
@@ -844,6 +844,7 @@ void impl3dsRunOneFrame(bool firstFrame, bool skipDrawingFrame)
 	notif3dsSync();
 
 	IPPU.RenderThisFrame = !skipDrawingFrame;
+	GPU3DSExt.hires.enabled = settings3DS.HiRes;
 
 	if (firstFrame)
 		Memory.ApplySpeedHackPatches();

--- a/source/3dsimpl.cpp
+++ b/source/3dsimpl.cpp
@@ -1139,9 +1139,11 @@ bool impl3dsTakeScreenshot(char *path, size_t bufferSize, bool renderFrame) {
     // Undo the buffer swap that C3D_FrameEnd performed internally
     // so gfxGetFramebuffer returns the buffer the GPU just wrote to.
     gfxScreenSwapBuffers(settings3DS.GameScreen, false);
-    impl3dsInvalidateScreen(settings3DS.GameScreen);
 
-    bool success = img3dsSaveScreenRegion(path, screenshot.width, screenshot.height, screenshot.x, screenshot.y, settings3DS.GameScreen);
+    bool isWide = gfxIsWide();
+    impl3dsInvalidateScreen(settings3DS.GameScreen, false, isWide);
+
+    bool success = img3dsSaveScreenRegion(path, screenshot.width, screenshot.height, screenshot.x, screenshot.y, settings3DS.GameScreen, false, isWide);
 	log3dsWrite("screenshot saved %s: %s", path, success ? "v" : "x");
 
 	if (success && isSavestate) {

--- a/source/3dsimpl.cpp
+++ b/source/3dsimpl.cpp
@@ -173,12 +173,12 @@ bool impl3dsInitialize()
 	u32 mode7Tile0TextureParams = GPU_TEXTURE_MAG_FILTER(GPU_NEAREST) | GPU_TEXTURE_MIN_FILTER(GPU_NEAREST) | GPU_TEXTURE_WRAP_S(GPU_REPEAT) | GPU_TEXTURE_WRAP_T(GPU_REPEAT);
 	
 	const SGPUTextureConfig vramTexConfig[] = {
-		{ defaultTextureParams, SNES_SUB, GPU_RGBA8, 256, 256 }, // VRAM Bank A
+		{ defaultTextureParams, SNES_SUB, GPU_RGBA8, 512, 256 }, // VRAM Bank A
 		{ mode7Tile0TextureParams, SNES_MODE7_TILE_0, GPU_RGBA5551, 16, 16 },
 
 		{ defaultTextureParams, SNES_MODE7_FULL, GPU_RGBA5551, 1024, 1024 }, // VRAM Bank A is full now -> VRAM Bank B
-		{ defaultTextureParams, SNES_MAIN, GPU_RGBA8, 256, 256 },
-		{ defaultTextureParams, SNES_DEPTH, GPU_RGBA8, 256, 256 }
+		{ defaultTextureParams, SNES_MAIN, GPU_RGBA8, 512, 256 },
+		{ defaultTextureParams, SNES_DEPTH, GPU_RGBA8, 512, 256 }
 	};
 
     const int totalVramTextures = static_cast<int>(sizeof(vramTexConfig) / sizeof(vramTexConfig[0]));

--- a/source/3dsimpl.cpp
+++ b/source/3dsimpl.cpp
@@ -811,7 +811,7 @@ void impl3dsSceneRender(bool firstFrame, bool paused) {
 
 	bool isFullScreen = gameScreenViewport.sWidth >= settings3DS.GameScreenWidth && gameScreenViewport.cHeight >= SCREEN_HEIGHT;
 	bool drawBackground = !isFullScreen;
-	bool isTopStereo = gpu3dsIs3DEnabled();
+	bool isTopStereo = GPU3DS.topMode == TOP_MODE_3D;
 	float xOffset = isTopStereo ? gpu3dsGetIOD() : 0.0f;
 	bool balancedFilterEnabled =
 		settings3DS.ScreenFilter == Setting::ScreenFilter::Balanced && !screenshot.dirty &&

--- a/source/3dsimpl.cpp
+++ b/source/3dsimpl.cpp
@@ -164,21 +164,18 @@ bool impl3dsInitialize()
 	// Main screen requires 8-bit alpha, otherwise alpha blending will not work well
 	// Mode7 texture requires 16x16 as a minimum
 	//
-	// Depth texture for the sub / main screens improves performance 
-	// -> Games like Axelay, F-Zero now run close to full speed!
-	//
 	log3dsWrite("allocate textures:");
 
 	u32 defaultTextureParams = GPU_TEXTURE_MAG_FILTER(GPU_NEAREST) | GPU_TEXTURE_MIN_FILTER(GPU_NEAREST) | GPU_TEXTURE_WRAP_S(GPU_CLAMP_TO_BORDER) | GPU_TEXTURE_WRAP_T(GPU_CLAMP_TO_BORDER);
 	u32 mode7Tile0TextureParams = GPU_TEXTURE_MAG_FILTER(GPU_NEAREST) | GPU_TEXTURE_MIN_FILTER(GPU_NEAREST) | GPU_TEXTURE_WRAP_S(GPU_REPEAT) | GPU_TEXTURE_WRAP_T(GPU_REPEAT);
 	
+	// Reorder with care (see libctru's vramAlloc bank load-balancing)
 	const SGPUTextureConfig vramTexConfig[] = {
-		{ defaultTextureParams, SNES_SUB, GPU_RGBA8, 512, 256 }, // VRAM Bank A
+		{ defaultTextureParams, SNES_DEPTH, GPU_RGBA8, 512, 256 },
 		{ mode7Tile0TextureParams, SNES_MODE7_TILE_0, GPU_RGBA5551, 16, 16 },
-
-		{ defaultTextureParams, SNES_MODE7_FULL, GPU_RGBA5551, 1024, 1024 }, // VRAM Bank A is full now -> VRAM Bank B
+		{ defaultTextureParams, SNES_MODE7_FULL, GPU_RGBA5551, 1024, 1024 },
 		{ defaultTextureParams, SNES_MAIN, GPU_RGBA8, 512, 256 },
-		{ defaultTextureParams, SNES_DEPTH, GPU_RGBA8, 512, 256 }
+		{ defaultTextureParams, SNES_SUB, GPU_RGBA8, 512, 256 }
 	};
 
     const int totalVramTextures = static_cast<int>(sizeof(vramTexConfig) / sizeof(vramTexConfig[0]));
@@ -194,11 +191,6 @@ bool impl3dsInitialize()
         	return false;
 		}
 
-		if (id == SNES_DEPTH) {
-			setDepthBufferByTex(GPU3DS.textures[SNES_MAIN].target, &texture->tex);
-			setDepthBufferByTex(GPU3DS.textures[SNES_SUB].target, &texture->tex);
-		}
-
 		log3dsWrite("ingame vram texture \"%s\" dim: %dx%d, size:%.2fkb, format: %s",
 			utils3dsTextureIDToString(texture->id),
 			texture->tex.width, texture->tex.height,
@@ -206,6 +198,11 @@ bool impl3dsInitialize()
 			utils3dsTexColorToString(texture->tex.fmt)
 		);
 	}
+
+	// Share one depth/stencil buffer across the main + sub screen targets.
+	// Improves performance in games like Axelay and F-Zero
+	setDepthBufferByTex(GPU3DS.textures[SNES_MAIN].target, &GPU3DS.textures[SNES_DEPTH].tex);
+	setDepthBufferByTex(GPU3DS.textures[SNES_SUB].target, &GPU3DS.textures[SNES_DEPTH].tex);
 
 	const SGPUTextureConfig lramTexConfig[] = {
 		{ defaultTextureParams, SNES_TILE_CACHE, GPU_RGBA5551, 1024, 1024 },

--- a/source/3dsimpl.cpp
+++ b/source/3dsimpl.cpp
@@ -844,7 +844,7 @@ void impl3dsRunOneFrame(bool firstFrame, bool skipDrawingFrame)
 	notif3dsSync();
 
 	IPPU.RenderThisFrame = !skipDrawingFrame;
-	GPU3DSExt.hires.enabled = settings3DS.HiRes;
+	GPU3DSExt.render2x.enabled = settings3DS.EnhancedResolution;
 
 	if (firstFrame)
 		Memory.ApplySpeedHackPatches();

--- a/source/3dsimpl.cpp
+++ b/source/3dsimpl.cpp
@@ -841,7 +841,6 @@ void impl3dsRunOneFrame(bool firstFrame, bool skipDrawingFrame)
 	notif3dsSync();
 
 	IPPU.RenderThisFrame = !skipDrawingFrame;
-	GPU3DSExt.render2x.enabled = settings3DS.EnhancedResolution;
 
 	if (firstFrame)
 		Memory.ApplySpeedHackPatches();

--- a/source/3dsimpl_gpu.cpp
+++ b/source/3dsimpl_gpu.cpp
@@ -445,6 +445,13 @@ void gpu3dsPrepareSnesScreenForNextFrame() {
 	gpu3dsPrepareListForNextFrame(&GPU3DS.vertices[VBO_SCENE_RECT], true);
 	gpu3dsPrepareListForNextFrame(&GPU3DS.vertices[VBO_SCENE_TILE], true);
 	gpu3dsPrepareListForNextFrame(&GPU3DS.vertices[VBO_SCENE_MODE7_LINE], true);
+
+    if (GPU3DSExt.render2x.dirty) {
+        gpu3dsClearTexture(&GPU3DS.textures[SNES_MAIN], 0);
+        gpu3dsClearTexture(&GPU3DS.textures[SNES_SUB], 0);
+        gpu3dsClearTexture(&GPU3DS.textures[SNES_DEPTH], 0);
+        GPU3DSExt.render2x.dirty = false;
+    }
 }
 
 void gpu3dsDrawSnesScreen() {

--- a/source/3dsimpl_gpu.h
+++ b/source/3dsimpl_gpu.h
@@ -176,9 +176,6 @@ typedef struct
 typedef struct
 {
     bool            enabled;
-    bool            active;
-    int             lastUpdateFrame;
-    bool            has2xMode;
     bool            dirty;
 } SRender2xState;
 
@@ -197,8 +194,9 @@ typedef struct
     bool            mode7SectionsModified[4];
     bool            mode7TilesModified;
 
-    SRender2xState  render2x;
-    int             renderWidth;  // 512 when render2x.active, else 256
+    SRender2xState  render2x;       // 512px internal SNES render path:
+                                    // true hires for Mode 5, finer Mode 7 sampling, doubled geometry elsewhere
+    int             renderWidth;    // 512 when render2x.enabled, else 256
 } SGPU3DSExtended;
 
 extern SGPU3DSExtended GPU3DSExt;

--- a/source/3dsimpl_gpu.h
+++ b/source/3dsimpl_gpu.h
@@ -175,9 +175,15 @@ typedef struct
 
 typedef struct
 {
+    bool            enabled;
+    bool            active;
+} SHiResState;
+
+typedef struct
+{
     u16             vramCacheHashToTexturePosition[MAX_HASH + 1]; // 262146 bytes
     int             vramCacheTexturePositionToHash[MAX_TEXTURE_HASH_POSITIONS]; // 4*MAX_TEXTURE_HASH_POSITIONS bytes
-    
+
     SLayerList      layerList;
 
     u32             newCacheTexturePosition;
@@ -187,6 +193,9 @@ typedef struct
     GPU_TEXCOLOR    mode7TextureFormat;
     bool            mode7SectionsModified[4];
     bool            mode7TilesModified;
+
+    SHiResState     hires;
+    int             renderWidth;  // 512 when hires.active, else 256
 } SGPU3DSExtended;
 
 extern SGPU3DSExtended GPU3DSExt;

--- a/source/3dsimpl_gpu.h
+++ b/source/3dsimpl_gpu.h
@@ -177,7 +177,10 @@ typedef struct
 {
     bool            enabled;
     bool            active;
-} SHiResState;
+    int             lastUpdateFrame;
+    bool            has2xMode;
+    bool            dirty;
+} SRender2xState;
 
 typedef struct
 {
@@ -194,8 +197,8 @@ typedef struct
     bool            mode7SectionsModified[4];
     bool            mode7TilesModified;
 
-    SHiResState     hires;
-    int             renderWidth;  // 512 when hires.active, else 256
+    SRender2xState  render2x;
+    int             renderWidth;  // 512 when render2x.active, else 256
 } SGPU3DSExtended;
 
 extern SGPU3DSExtended GPU3DSExt;

--- a/source/3dslcd.cpp
+++ b/source/3dslcd.cpp
@@ -19,7 +19,7 @@ static u32 computeVtotal(double targetFps, u32 defaultVtotalBottom) {
 }
 
 static void writeVtotal(u32 vtotal2D) {
-    u32 vtop = (gpu3dsIs3DEnabled() || gfxIsWide()) ? vtotal2D * 2 + 1 : vtotal2D;
+    u32 vtop = (GPU3DS.topMode != TOP_MODE_2D) ? vtotal2D * 2 + 1 : vtotal2D;
     u32 vbot = vtotal2D;
     GSPGPU_WriteHWRegs(PDC_VTOTAL_TOP, &vtop, 4);
     GSPGPU_WriteHWRegs(PDC_VTOTAL_BOTTOM, &vbot, 4);
@@ -50,7 +50,7 @@ void lcd3dsRestoreDefaultRate() {
     // Top VTotal depends on top-screen mode (2D, 3D, WIDE): 
     // restoring a stale 3D/Wide value while in 2D can leave the top screen
     // in a broken timing state after menu toggles.
-    u32 vtotalTop = (gpu3dsIs3DEnabled() || gfxIsWide()) ? savedVtotalBottom * 2 + 1 : savedVtotalBottom;
+    u32 vtotalTop = (GPU3DS.topMode != TOP_MODE_2D) ? savedVtotalBottom * 2 + 1 : savedVtotalBottom;
     GSPGPU_WriteHWRegs(PDC_VTOTAL_TOP, &vtotalTop, 4);
     GSPGPU_WriteHWRegs(PDC_VTOTAL_BOTTOM, &savedVtotalBottom, 4);
 }

--- a/source/3dslcd.cpp
+++ b/source/3dslcd.cpp
@@ -19,7 +19,7 @@ static u32 computeVtotal(double targetFps, u32 defaultVtotalBottom) {
 }
 
 static void writeVtotal(u32 vtotal2D) {
-    u32 vtop = gpu3dsIs3DEnabled() ? vtotal2D * 2 + 1 : vtotal2D;
+    u32 vtop = (gpu3dsIs3DEnabled() || gfxIsWide()) ? vtotal2D * 2 + 1 : vtotal2D;
     u32 vbot = vtotal2D;
     GSPGPU_WriteHWRegs(PDC_VTOTAL_TOP, &vtop, 4);
     GSPGPU_WriteHWRegs(PDC_VTOTAL_BOTTOM, &vbot, 4);
@@ -47,9 +47,10 @@ void lcd3dsRestoreDefaultRate() {
 
     vtotalActive = false;
     gspWaitForVBlank();
-    // Top VTotal depends on 3D mode: restoring a stale 3D value while in 2D
-    // can leave the top screen in a broken timing state after menu toggles.
-    u32 vtotalTop = gpu3dsIs3DEnabled() ? savedVtotalBottom * 2 + 1 : savedVtotalBottom;
+    // Top VTotal depends on top-screen mode (2D, 3D, WIDE): 
+    // restoring a stale 3D/Wide value while in 2D can leave the top screen
+    // in a broken timing state after menu toggles.
+    u32 vtotalTop = (gpu3dsIs3DEnabled() || gfxIsWide()) ? savedVtotalBottom * 2 + 1 : savedVtotalBottom;
     GSPGPU_WriteHWRegs(PDC_VTOTAL_TOP, &vtotalTop, 4);
     GSPGPU_WriteHWRegs(PDC_VTOTAL_BOTTOM, &savedVtotalBottom, 4);
 }

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -509,7 +509,7 @@ void makeEmulatorMenu(std::vector<SMenuItem>& items, std::vector<SMenuTab>& menu
             log3dsWrite("screen swapped");
         });
 
-    if (gpu3dsIs3DAvailable() && settings3DS.GameScreen == GFX_TOP && !settings3DS.EnhancedResolution) {
+    if (gpu3dsIs3DAvailable() && settings3DS.GameScreen == GFX_TOP && settings3DS.EnhancedResolution != Setting::EnhancedResolution::Wide) {
         AddMenuCheckbox(items, "  3D Enabled"_s, !settings3DS.Disable3DSlider,
             []( int val ) {
                 if (!CheckAndUpdateToggle(settings3DS.Disable3DSlider, !val)) {
@@ -627,7 +627,24 @@ std::vector<SMenuItem> makeOptionsForStretch() {
     if (settings3DS.GameScreen == GFX_TOP) {
         AddMenuDialogOption(items, static_cast<int>(Setting::ScreenStretch::Full), "Fullscreen"_s,               "Stretch to 400x240");
     }
-    
+
+    return items;
+}
+
+std::vector<SMenuItem> makeOptionsForEnhancedResolution() {
+    std::vector<SMenuItem> items;
+    items.reserve(3);
+
+    // "2x Screen" (wide 800px panel) only exists on a wide-capable device's top screen.
+    if (gpu3dsIsWideAvailable() && settings3DS.GameScreen == GFX_TOP) {
+        AddMenuDialogOption(items, static_cast<int>(Setting::EnhancedResolution::Off),        "Off"_s);
+        AddMenuDialogOption(items, static_cast<int>(Setting::EnhancedResolution::Standard),   "Standard"_s,   "Slightly sharper, keeps 3D"_s);
+        AddMenuDialogOption(items, static_cast<int>(Setting::EnhancedResolution::Wide), "2x Screen"_s,  "Most detail, disables 3D"_s);
+    } else {
+        AddMenuDialogOption(items, static_cast<int>(Setting::EnhancedResolution::Off),      "Off"_s);
+        AddMenuDialogOption(items, static_cast<int>(Setting::EnhancedResolution::Standard), "On"_s);
+    }
+
     return items;
 }
 
@@ -746,7 +763,7 @@ void makeOptionMenu(std::vector<SMenuItem>& items, std::vector<SMenuTab>& menuTa
 
     AddMenuHeader1(items, "GENERAL SETTINGS"_s);
     AddMenuHeader2(items, "Video"_s);
-    AddMenuPicker(items, "  Scaling"_s, "Change video scaling settings"_s, makeOptionsForStretch(), static_cast<int>(settings3DS.ScreenStretch), DIALOG_TYPE_INFO, true,
+    AddMenuPicker(items, "  Scaling"_s, "Sets how the picture fills the screen. Stretched modes\npair well with Enhanced Resolution for a sharper look."_s, makeOptionsForStretch(), static_cast<int>(settings3DS.ScreenStretch), DIALOG_TYPE_INFO, true,
                   []( int val ) { 
                     if (CheckAndUpdate( settings3DS.ScreenStretch, static_cast<Setting::ScreenStretch>(val) )) { 
                         settings3dsApplyScreenStretch(); 
@@ -754,11 +771,33 @@ void makeOptionMenu(std::vector<SMenuItem>& items, std::vector<SMenuTab>& menuTa
                     } 
                 });
     
-    AddMenuPicker(items, "  Scale Filter"_s, "Used only when image is scaled.\nScaling = \"No Stretch\" always stays pixel-perfect.\nFilter = \"Balanced\" may reduce performance slightly."_s,
+    AddMenuPicker(items, "  Scale Filter"_s, "Applies when the game screen is stretched/zoomed in.\n\"Sharp\" may distort details,\n\"Balanced\" has minor performance impact."_s,
         makeOptionsForScreenFilter(), static_cast<int>(settings3DS.ScreenFilter), DIALOG_TYPE_INFO, true,
         []( int val ) {
             if (CheckAndUpdate(settings3DS.ScreenFilter, static_cast<Setting::ScreenFilter>(val))) {
                 menu3dsSetScreenDirty();
+            }
+        });
+
+
+    bool wideOptionAvailable = gpu3dsIsWideAvailable() && settings3DS.GameScreen == GFX_TOP;
+    // preserve wide setting when switching game screen to bottom screen,
+    // show it as Standard/On in picker
+    int enhancedResolutionValue = static_cast<int>(settings3DS.EnhancedResolution);
+    if (!wideOptionAvailable && settings3DS.EnhancedResolution == Setting::EnhancedResolution::Wide)
+        enhancedResolutionValue = static_cast<int>(Setting::EnhancedResolution::Standard);
+
+    AddMenuPicker(items, "  Enhanced Resolution"_s,
+        wideOptionAvailable
+            ? "Renders at higher resolution for a sharper, more\ndetailed picture. Recommended when stretched modes\nare used. 2x Screen has most performance impact."_s
+            : "Sharpens the picture slightly, when stretched modes are used.\nLittle effect at \"No Stretch\"."_s,
+        makeOptionsForEnhancedResolution(), enhancedResolutionValue, DIALOG_TYPE_INFO, true,
+        []( int val ) {
+            if (CheckAndUpdate( settings3DS.EnhancedResolution, static_cast<Setting::EnhancedResolution>(val) )) {
+                GPU3DSExt.render2x.dirty = true;
+                // 2x Screen takes over from 3D; rebuild so the 3D row shows/hides
+                menu3dsMarkTabDirty(TAB_EMULATOR);
+                menu3dsSetScreenDirty(true, true);
             }
         });
 
@@ -890,21 +929,8 @@ void makeOptionMenu(std::vector<SMenuItem>& items, std::vector<SMenuTab>& menuTa
     AddMenuCheckbox(items, "  Mode 7 Smoothing"_s, settings3DS.Mode7BilinearFilter,
         []( int val ) { CheckAndUpdateToggle( settings3DS.Mode7BilinearFilter, val ); });
 
-    if (gpu3dsIsWideAvailable() && settings3DS.GameScreen == GFX_TOP) {
-        AddMenuCheckbox(items, "  Enhanced Resolution"_s, settings3DS.EnhancedResolution,
-            []( int val ) { 
-                if (CheckAndUpdateToggle( settings3DS.EnhancedResolution, val )) {
-                    GPU3DSExt.render2x.dirty = true;
-                    // wide takes over from 3D; rebuild so the 3D row shows/hides
-                    menu3dsMarkTabDirty(TAB_EMULATOR);
-                    menu3dsSetScreenDirty(true, true);
-                }
-            });
-        items.emplace_back(nullptr, MenuItemType::Textarea, "  Sharper, more detailed picture (slower).\n  Takes over from 3D while enabled."_s, ""_s);
-    }
-
     AddMenuDisabledOption(items, ""_s);
-
+    
     AddMenuHeader2(items, "Audio"_s);
     AddMenuPicker(items, "  Volume Amplification"_s, "Boosts the game's volume. 100% = unamplified.\nHigh values may reduce audio quality on loud games."_s, makePickerOptions({"100%", "125%", "150%", "175%", "200%"}),
                 settings3DS.UseGlobalVolume ? settings3DS.GlobalVolume : settings3DS.Volume, DIALOG_TYPE_INFO, true,
@@ -1198,7 +1224,7 @@ bool settingsReadWriteFullListByGame(bool writeMode)
     }
 
     if (writeMode || detectedConfigVersion >= 1.5f) {
-        config3dsReadWriteEnum(stream, writeMode, "EnhancedResolution=%d\n", &settings3DS.EnhancedResolution, 0, 1);
+        config3dsReadWriteEnum(stream, writeMode, "EnhancedResolution=%d\n", &settings3DS.EnhancedResolution, 0, 2);
     }
     
     config3dsReadWriteInt32(stream, writeMode, "Frameskips=%d\n", &settings3DS.MaxFrameSkips, 0, 4);
@@ -2099,6 +2125,8 @@ void emulatorLoop()
     }
 
     gpu3dsResetState();
+
+    GPU3DSExt.render2x.enabled = settings3DS.EnhancedResolution != Setting::EnhancedResolution::Off;
 
     // render one frame before lcd3dsSetEmulationRate below,
     // otherwise game screen glitches and real hardware freezes.

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -2085,6 +2085,14 @@ void emulatorLoop()
 
     gpu3dsResetState();
 
+    // render one frame before lcd3dsSetEmulationRate below,
+    // otherwise game screen glitches and real hardware freezes.
+    if (gpu3dsSetWideMode(settings3DS.HiRes)) {
+        gpu3dsFrameBegin(C3D_FRAME_SYNCDRAW, false);
+            impl3dsSceneRender(true);
+        gpu3dsFrameEnd();
+    }
+
     if (GPU3DS.profilingMode == PROFILING_OFF) {
         for (int pass = 0; pass < 2; pass++) {
             gpu3dsFrameBegin(C3D_FRAME_SYNCDRAW, false, true);

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -502,10 +502,14 @@ void makeEmulatorMenu(std::vector<SMenuItem>& items, std::vector<SMenuTab>& menu
             menu3dsSetScreenDirty(true, true);
             ui3dsSetScreenLayout();
             menu3dsMarkTabDirty(TAB_EMULATOR);
+            if (settings3DS.isRomLoaded) {
+                menu3dsMarkTabDirty(TAB_SETTINGS);
+            }
+
             log3dsWrite("screen swapped");
         });
 
-    if (gpu3dsIs3DAvailable() && settings3DS.GameScreen == GFX_TOP) {
+    if (gpu3dsIs3DAvailable() && settings3DS.GameScreen == GFX_TOP && !settings3DS.EnhancedResolution) {
         AddMenuCheckbox(items, "  3D Enabled"_s, !settings3DS.Disable3DSlider,
             []( int val ) {
                 if (!CheckAndUpdateToggle(settings3DS.Disable3DSlider, !val)) {
@@ -886,14 +890,18 @@ void makeOptionMenu(std::vector<SMenuItem>& items, std::vector<SMenuTab>& menuTa
     AddMenuCheckbox(items, "  Mode 7 Smoothing"_s, settings3DS.Mode7BilinearFilter,
         []( int val ) { CheckAndUpdateToggle( settings3DS.Mode7BilinearFilter, val ); });
 
-    AddMenuCheckbox(items, "  Enhanced Resolution"_s, settings3DS.EnhancedResolution,
-        []( int val ) { 
-            if (CheckAndUpdateToggle( settings3DS.EnhancedResolution, val )) {
-                GPU3DSExt.render2x.dirty = true;
-                menu3dsSetScreenDirty();
-            } 
-        });
-    items.emplace_back(nullptr, MenuItemType::Textarea, "  Sharper, more detailed picture (slower)"_s, ""_s);
+    if (gpu3dsIsWideAvailable() && settings3DS.GameScreen == GFX_TOP) {
+        AddMenuCheckbox(items, "  Enhanced Resolution"_s, settings3DS.EnhancedResolution,
+            []( int val ) { 
+                if (CheckAndUpdateToggle( settings3DS.EnhancedResolution, val )) {
+                    GPU3DSExt.render2x.dirty = true;
+                    // wide takes over from 3D; rebuild so the 3D row shows/hides
+                    menu3dsMarkTabDirty(TAB_EMULATOR);
+                    menu3dsSetScreenDirty(true, true);
+                }
+            });
+        items.emplace_back(nullptr, MenuItemType::Textarea, "  Sharper, more detailed picture (slower).\n  Takes over from 3D while enabled."_s, ""_s);
+    }
 
     AddMenuDisabledOption(items, ""_s);
 
@@ -1863,7 +1871,7 @@ void showMenu() {
 
     // 1. first boot
     // 2. new game loaded
-    if (menuTabs.empty() || Memory.ROMCRC32 != lastLoadedRomCRC || menu3dsAnyTabDirty())
+    if (menuTabs.empty() || Memory.ROMCRC32 != lastLoadedRomCRC || menu3dsHasDirtyTabs())
     {
         setupMenu(currentMenuTab);
         lastLoadedRomCRC = Memory.ROMCRC32;
@@ -1878,7 +1886,7 @@ void showMenu() {
     while (aptMainLoop() && GPU3DS.emulatorState == EMUSTATE_PAUSEMENU) {
         int result = menu3dsMenuSelectItem(dialogTab, isDialog, currentMenuTab, menuTabs);
 
-        if (menu3dsAnyTabDirty())
+        if (menu3dsHasDirtyTabs())
         {
             setupMenu(currentMenuTab);
         }
@@ -2094,7 +2102,7 @@ void emulatorLoop()
 
     // render one frame before lcd3dsSetEmulationRate below,
     // otherwise game screen glitches and real hardware freezes.
-    if (gpu3dsSetWideMode(settings3DS.EnhancedResolution)) {
+    if (gpu3dsSetTopMode()) {
         gpu3dsFrameBegin(C3D_FRAME_SYNCDRAW, false);
             impl3dsSceneRender(true);
         gpu3dsFrameEnd();

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -886,6 +886,9 @@ void makeOptionMenu(std::vector<SMenuItem>& items, std::vector<SMenuTab>& menuTa
     AddMenuCheckbox(items, "  Mode 7 Smoothing"_s, settings3DS.Mode7BilinearFilter,
         []( int val ) { CheckAndUpdateToggle( settings3DS.Mode7BilinearFilter, val ); });
 
+    AddMenuCheckbox(items, "  HiRes Enabled"_s, settings3DS.HiRes,
+        []( int val ) { CheckAndUpdateToggle( settings3DS.HiRes, val ); });
+
     AddMenuDisabledOption(items, ""_s);
 
     AddMenuHeader2(items, "Audio"_s);
@@ -1178,6 +1181,10 @@ bool settingsReadWriteFullListByGame(bool writeMode)
         config3dsReadWriteEnum(stream, writeMode, "FrameSync=%d\n", &settings3DS.FrameSync, 0, 1);
         config3dsReadWriteEnum(stream, writeMode, "Mode7BilinearFilter=%d\n", &settings3DS.Mode7BilinearFilter, 0, 1);
         config3dsReadWriteInt32(stream, writeMode, "AudioBuffer=%d\n", &settings3DS.AudioBuffer, 0, 2);
+    }
+
+    if (writeMode || detectedConfigVersion >= 1.5f) {
+        config3dsReadWriteEnum(stream, writeMode, "HiRes=%d\n", &settings3DS.HiRes, 0, 1);
     }
     
     config3dsReadWriteInt32(stream, writeMode, "Frameskips=%d\n", &settings3DS.MaxFrameSkips, 0, 4);

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -886,8 +886,14 @@ void makeOptionMenu(std::vector<SMenuItem>& items, std::vector<SMenuTab>& menuTa
     AddMenuCheckbox(items, "  Mode 7 Smoothing"_s, settings3DS.Mode7BilinearFilter,
         []( int val ) { CheckAndUpdateToggle( settings3DS.Mode7BilinearFilter, val ); });
 
-    AddMenuCheckbox(items, "  HiRes Enabled"_s, settings3DS.HiRes,
-        []( int val ) { CheckAndUpdateToggle( settings3DS.HiRes, val ); });
+    AddMenuCheckbox(items, "  Enhanced Resolution"_s, settings3DS.EnhancedResolution,
+        []( int val ) { 
+            if (CheckAndUpdateToggle( settings3DS.EnhancedResolution, val )) {
+                GPU3DSExt.render2x.dirty = true;
+                menu3dsSetScreenDirty();
+            } 
+        });
+    items.emplace_back(nullptr, MenuItemType::Textarea, "  Sharper, more detailed picture (slower)"_s, ""_s);
 
     AddMenuDisabledOption(items, ""_s);
 
@@ -1184,7 +1190,7 @@ bool settingsReadWriteFullListByGame(bool writeMode)
     }
 
     if (writeMode || detectedConfigVersion >= 1.5f) {
-        config3dsReadWriteEnum(stream, writeMode, "HiRes=%d\n", &settings3DS.HiRes, 0, 1);
+        config3dsReadWriteEnum(stream, writeMode, "EnhancedResolution=%d\n", &settings3DS.EnhancedResolution, 0, 1);
     }
     
     config3dsReadWriteInt32(stream, writeMode, "Frameskips=%d\n", &settings3DS.MaxFrameSkips, 0, 4);
@@ -1439,6 +1445,7 @@ bool emulatorLoadRom()
 
     // clear stale data
     gpu3dsClearTexture(&GPU3DS.textures[SNES_MAIN], 0);
+    gpu3dsClearTexture(&GPU3DS.textures[SNES_SUB], 0);
     gpu3dsClearTexture(&GPU3DS.textures[SNES_DEPTH], 0);
 
     // update global config
@@ -2087,7 +2094,7 @@ void emulatorLoop()
 
     // render one frame before lcd3dsSetEmulationRate below,
     // otherwise game screen glitches and real hardware freezes.
-    if (gpu3dsSetWideMode(settings3DS.HiRes)) {
+    if (gpu3dsSetWideMode(settings3DS.EnhancedResolution)) {
         gpu3dsFrameBegin(C3D_FRAME_SYNCDRAW, false);
             impl3dsSceneRender(true);
         gpu3dsFrameEnd();

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -1100,11 +1100,16 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
             secondScreenDirty = true;
         }
 
-        const bool set3DEnabled =
-            gpu3dsIs3DAvailable()
-            && !settings3DS.Disable3DSlider
-            && settings3DS.GameScreen == GFX_TOP;
-        gfxSet3D(set3DEnabled);
+        bool set3DEnabled = false;
+
+        if (!gfxIsWide()) {
+            set3DEnabled =
+                gpu3dsIs3DAvailable()
+                && !settings3DS.Disable3DSlider
+                && settings3DS.GameScreen == GFX_TOP;
+            gfxSet3D(set3DEnabled);
+        }
+        
         float iod = set3DEnabled ? gpu3dsGetIOD() : 0.0f;
 
         if (!isDialog && iod != prevIOD) {

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -102,7 +102,7 @@ void menu3dsDrawSplash(float fade = 1.0f)
     if (settings3DS.isRomLoaded)
         return;
 
-    bool isTopStereo = gpu3dsIs3DEnabled();
+    bool isTopStereo = GPU3DS.topMode == TOP_MODE_3D;
     float iod = isTopStereo ? gpu3dsGetIOD() : 0;
 
     GSPGPU_FramebufferFormat gpuBufFmt = (GSPGPU_FramebufferFormat)DISPLAY_TRANSFER_FMT;
@@ -948,7 +948,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                 item.SetValue(item.Value);
                 secondScreenDirty = true;
 
-                if (menu3dsTabIsDirty(currentMenuTab, menuTabs)) {
+                if (menu3dsHasDirtyTabs()) {
                     returnResult = -1;
                     break;
                 }
@@ -968,7 +968,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
 
                 secondScreenDirty = true;
 
-                if (menu3dsTabIsDirty(currentMenuTab, menuTabs)) {
+                if (menu3dsHasDirtyTabs()) {
                     returnResult = -1;
                     break;
                 }
@@ -1014,7 +1014,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
 
                 secondScreenDirty = true;
 
-                if (menu3dsTabIsDirty(currentMenuTab, menuTabs)) {
+                if (menu3dsHasDirtyTabs()) {
                     returnResult = -1;
                     break;
                 }
@@ -1100,18 +1100,9 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
             secondScreenDirty = true;
         }
 
-        gpu3dsSetWideMode(settings3DS.EnhancedResolution);
-        bool set3DEnabled = false;
+        gpu3dsSetTopMode();
 
-        if (!gfxIsWide()) {
-            set3DEnabled =
-                gpu3dsIs3DAvailable()
-                && !settings3DS.Disable3DSlider
-                && settings3DS.GameScreen == GFX_TOP;
-            gfxSet3D(set3DEnabled);
-        }
-        
-        float iod = set3DEnabled ? gpu3dsGetIOD() : 0.0f;
+        float iod = GPU3DS.topMode == TOP_MODE_3D ? gpu3dsGetIOD() : 0.0f;
 
         if (!isDialog && iod != prevIOD) {
             gameScreenDirty = true;
@@ -1138,7 +1129,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                         impl3dsSceneRender(true, true);
                         notif3dsHide();
                     } else {
-                        bool isTopStereo = gpu3dsIs3DEnabled();
+                        bool isTopStereo = GPU3DS.topMode == TOP_MODE_3D;
                         gpu3dsClearScreen(settings3DS.GameScreen, isTopStereo);
                         img3dsDrawSplash(UI_SPLASH, isTopStereo, iod);
                     }
@@ -1239,13 +1230,7 @@ void menu3dsMarkTabDirty(int tab) {
         settings3DS.menuTabDirty[tab] = true;
 }
 
-bool menu3dsTabIsDirty(int tab, const std::vector<SMenuTab>& menuTabs) {
-    // Load-Game tab is never dirty-tracked, so bound by menuTabs.size() - 1
-    return tab >= 0 && tab < static_cast<int>(menuTabs.size()) - 1
-        && settings3DS.menuTabDirty[tab];
-}
-
-bool menu3dsAnyTabDirty() {
+bool menu3dsHasDirtyTabs() {
     for (int i = 0; i < TAB_DIRTY_COUNT; i++)
         if (settings3DS.menuTabDirty[i])
             return true;

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -1100,6 +1100,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
             secondScreenDirty = true;
         }
 
+        gpu3dsSetWideMode(settings3DS.EnhancedResolution);
         bool set3DEnabled = false;
 
         if (!gfxIsWide()) {

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -176,8 +176,7 @@ void menu3dsSelectRandomGameIndex(SMenuTab& currentTab, int min, int max, int la
 void menu3dsSetScreenDirty(bool gameScreen = true, bool secondScreen = false);
 
 void menu3dsMarkTabDirty(int tab);
-bool menu3dsTabIsDirty(int tab, const std::vector<SMenuTab>& menuTabs);
-bool menu3dsAnyTabDirty();
+bool menu3dsHasDirtyTabs();
 
 std::string menu3dsGetRomInfo();
 void menu3dsSetHotkeysData(const char* hotkeysData[HOTKEYS_COUNT][3]);

--- a/source/3dssettings.cpp
+++ b/source/3dssettings.cpp
@@ -73,6 +73,7 @@ void settings3dsResetGameDefaults() {
     settings3DS.FrameSync = Setting::FrameSync::VBlank;
     settings3DS.PaletteFix = 0;
     settings3DS.Mode7BilinearFilter = false;
+    settings3DS.HiRes = false;
     settings3DS.CropEnabled = false;
     settings3DS.CropTop = 0;
     settings3DS.CropBottom = 0;

--- a/source/3dssettings.cpp
+++ b/source/3dssettings.cpp
@@ -73,7 +73,7 @@ void settings3dsResetGameDefaults() {
     settings3DS.FrameSync = Setting::FrameSync::VBlank;
     settings3DS.PaletteFix = 0;
     settings3DS.Mode7BilinearFilter = false;
-    settings3DS.EnhancedResolution = false;
+    settings3DS.EnhancedResolution = Setting::EnhancedResolution::Off;
     settings3DS.CropEnabled = false;
     settings3DS.CropTop = 0;
     settings3DS.CropBottom = 0;

--- a/source/3dssettings.cpp
+++ b/source/3dssettings.cpp
@@ -73,7 +73,7 @@ void settings3dsResetGameDefaults() {
     settings3DS.FrameSync = Setting::FrameSync::VBlank;
     settings3DS.PaletteFix = 0;
     settings3DS.Mode7BilinearFilter = false;
-    settings3DS.HiRes = false;
+    settings3DS.EnhancedResolution = false;
     settings3DS.CropEnabled = false;
     settings3DS.CropTop = 0;
     settings3DS.CropBottom = 0;

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -98,6 +98,12 @@ namespace Setting {
         Medium,
         High,
     };
+
+    enum class EnhancedResolution {
+        Off,         // native 256px render
+        Standard,    // 512px internal render (keeps 3D)
+        Wide,        // 512px internal render + wide 800px screen (disables 3D)
+    };
 }
 
 template <int Count>
@@ -195,7 +201,7 @@ typedef struct {
                                                 // texture. Default false; opt-in because it
                                                 // changes the characteristic Mode 7 look.
 
-    bool                EnhancedResolution;     // true hi-res Mode 5 at 512px and 2x horizontal Mode 7
+    Setting::EnhancedResolution EnhancedResolution;  // Off / Standard (512px render) / 2x Screen (512px + wide)
 
     int                 Volume;                 // 0: 100%, 1: 125%, 2: 150%, 3: 175%, 4: 200%
     int                 GlobalVolume;

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -195,7 +195,7 @@ typedef struct {
                                                 // texture. Default false; opt-in because it
                                                 // changes the characteristic Mode 7 look.
 
-    bool                HiRes;                  // opt-in due to the extra render cost on hi-res scenes
+    bool                EnhancedResolution;     // true hi-res Mode 5 at 512px and 2x horizontal Mode 7
 
     int                 Volume;                 // 0: 100%, 1: 125%, 2: 150%, 3: 175%, 4: 200%
     int                 GlobalVolume;

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -195,6 +195,8 @@ typedef struct {
                                                 // texture. Default false; opt-in because it
                                                 // changes the characteristic Mode 7 look.
 
+    bool                HiRes;                  // opt-in due to the extra render cost on hi-res scenes
+
     int                 Volume;                 // 0: 100%, 1: 125%, 2: 150%, 3: 175%, 4: 200%
     int                 GlobalVolume;
 

--- a/source/3dsui_img.cpp
+++ b/source/3dsui_img.cpp
@@ -842,7 +842,7 @@ void img3dsInvalidateStateScreenshot() {
 }
 
 bool img3dsSaveScreenRegion(const char* path,
-    int width, int height, int x0, int y0, gfxScreen_t screen, bool isTopStereo) {
+    int width, int height, int x0, int y0, gfxScreen_t screen, bool isTopStereo, bool isWide) {
     if (!g_fileBuffer) return false;
 
     u8* fb = (u8*)gfxGetFramebuffer(screen, GFX_LEFT, NULL, NULL);
@@ -851,20 +851,32 @@ bool img3dsSaveScreenRegion(const char* path,
     const int bpp = gpu3dsGetPixelSize(GPU_RGB8);
     const int stride = SCREEN_HEIGHT * bpp;
 
+    // In wide mode the physical top framebuffer is 800px.
+    // Read the doubled region and average column pairs back down,
+    // so the saved image keeps its normal dimensions
+    const int xStep = isWide ? 2 : 1;
+
     for (int y = 0; y < height; y++) {
         int img_y = y0 + y;
         int col = SCREEN_HEIGHT - 1 - img_y;
-        u8* src = fb + (x0 * stride) + (col * bpp);
-        
+        u8* src = fb + (x0 * xStep * stride) + (col * bpp);
+
         u8* dstRow = dst + (y * width * bpp);
 
         for (int x = 0; x < width; x++) {
-            dstRow[0] = src[2];
-            dstRow[1] = src[1];
-            dstRow[2] = src[0];
+            if (xStep == 2) {
+                u8* src2 = src + stride;
+                dstRow[0] = (src[2] + src2[2]) >> 1;
+                dstRow[1] = (src[1] + src2[1]) >> 1;
+                dstRow[2] = (src[0] + src2[0]) >> 1;
+            } else {
+                dstRow[0] = src[2];
+                dstRow[1] = src[1];
+                dstRow[2] = src[0];
+            }
 
             dstRow += bpp;
-            src += stride;
+            src += stride * xStep;
         }
     }
 

--- a/source/3dsui_img.cpp
+++ b/source/3dsui_img.cpp
@@ -178,7 +178,7 @@ bool img3dsAllocVramTextures() {
         FILE *file = fopen("romfs:/gfx/splash.t3x", "rb");
         if (!file) return false;
 
-        textureInfo[idx] = Tex3DS_TextureImportStdio(file, &texture->tex, NULL, true);
+        textureInfo[idx] = Tex3DS_TextureImportStdio(file, &texture->tex, NULL, false);
         fclose(file);
 
         if (!textureInfo[idx]) return false;

--- a/source/3dsui_img.h
+++ b/source/3dsui_img.h
@@ -29,7 +29,7 @@ void img3dsDrawThumb(int offsetRight, int offsetBottom);
 int img3dsGetThumbHeight();
 int img3dsGetThumbWidth();
 
-bool img3dsSaveScreenRegion(const char* path, int width, int height, int x0, int y0, gfxScreen_t screen, bool isTopStereo = false);
+bool img3dsSaveScreenRegion(const char* path, int width, int height, int x0, int y0, gfxScreen_t screen, bool isTopStereo = false, bool isWide = false);
 
 bool img3dsInitialize();
 void img3dsFinalize();

--- a/source/Snes9x/gfxhw.cpp
+++ b/source/Snes9x/gfxhw.cpp
@@ -780,9 +780,10 @@ inline void __attribute__((always_inline)) S9xDrawBGFullTileHardwareInline (
 
 	// Render tile
 	//
-	int x0 = screenX;
+	int hiShift = GPU3DSExt.render2x.active ? 1 : 0;
+	int x0 = screenX << hiShift;
 	int y0 = screenY + (prio == 0 ? depth0 : depth1);
-	int x1 = x0 + 8;
+	int x1 = x0 + (8 << hiShift);
 	int y1 = y0 + height;
 
 	int tx0 = 0;
@@ -887,7 +888,7 @@ inline void __attribute__((always_inline)) S9xDrawHiresBGFullTileHardwareInline 
         cache3dsCacheSnesTileToTexturePosition(pCache, screenColors, texturePos);
     }
 
-	bool fullWidth = GPU3DSExt.hires.active;
+	bool fullWidth = GPU3DSExt.render2x.active;
 	int x0 = fullWidth ? screenX : (screenX >> 1);
 	int y0 = screenY + (prio == 0 ? depth0 : depth1);
 
@@ -1994,6 +1995,7 @@ void S9xDrawBackgroundMosaicHardware(
     int YEnd   = (int)GFX.EndY + 1;
     int MosaicOffset = YStart % S;
     int FirstBlockH = S - MosaicOffset;
+	int hiShift = GPU3DSExt.render2x.active ? 1 : 0;
 
     for (int Y = YStart; Y < YEnd; )
     {
@@ -2121,7 +2123,6 @@ void S9xDrawBackgroundMosaicHardware(
 
             int blockW = (X + outBlockW > 256) ? (256 - X) : outBlockW;
 
-            int hiShift = GPU3DSExt.hires.active ? 1 : 0;
             int yDepth = (tpriority == 0 ? depth0 : depth1);
             int x0 = X << hiShift;
             int y0 = Y + yDepth;
@@ -2578,7 +2579,7 @@ inline void __attribute__((always_inline)) S9xDrawOBJTileHardware2 (
 		depth = depth & 0xfff;		// remove the alpha.
 
 	// at full 512px, texels are stretched 1->2px via nearest
-	int hiShift = GPU3DSExt.hires.active ? 1 : 0;
+	int hiShift = GPU3DSExt.render2x.active ? 1 : 0;
 	int x0 = screenX << hiShift;
 	int y0 = screenY + depth;
 
@@ -3078,6 +3079,7 @@ void S9xDrawBackgroundMode7Hardware(int bg, bool8 sub, int depth, int alphaTestA
 	else
 		alphaTest = GFX.r2131 & 0x40 ? ALPHA_TEST_GTE_0_5 : ALPHA_TEST_GTE_1_0;
 	
+	int hiShift = GPU3DSExt.render2x.active ? 1 : 0;
 
 	for (int Y = (int)LayerRender.startY[bg]; Y <= (int)GFX.EndY; Y++)
 	{
@@ -3125,7 +3127,7 @@ void S9xDrawBackgroundMode7Hardware(int bg, bool8 sub, int depth, int alphaTestA
 		float ty1 = (float)(CC1 + DD) * INV_M7_SCALE;
 
 		// using -16384 for the geometry shader to detect mode 7
-		gpu3dsAddMode7LineVertexes(Left, Y+depth, Right, -16384, tx0, ty0, tx1, ty1);
+		gpu3dsAddMode7LineVertexes(Left << hiShift, Y+depth, Right << hiShift, -16384, tx0, ty0, tx1, ty1);
 	}
 
 	layerVerticesCount[bg] = GPU3DS.vertices[VBO_SCENE_MODE7_LINE].count;
@@ -3140,6 +3142,7 @@ void S9xDrawBackgroundMode7Hardware(int bg, bool8 sub, int depth, int alphaTestA
 void S9xDrawBackgroundMode7HardwareRepeatTile0(int bg, bool8 sub, int depth)
 {
 	bool verticesUpdated = false;
+	int hiShift = GPU3DSExt.render2x.active ? 1 : 0;
 	
 	for (int Y = (int)LayerRender.startY[bg]; Y <= (int)GFX.EndY; Y++)
 	{
@@ -3189,7 +3192,7 @@ void S9xDrawBackgroundMode7HardwareRepeatTile0(int bg, bool8 sub, int depth)
 		if (!withinTexture)
 		{
 			// using -16384 for the geometry shader to detect mode 7
-			gpu3dsAddMode7LineVertexes(Left, Y+depth, Right, -16384, tx0, ty0, tx1, ty1);
+			gpu3dsAddMode7LineVertexes(Left << hiShift, Y+depth, Right << hiShift, -16384, tx0, ty0, tx1, ty1);
 
 			verticesUpdated = true;
 		}
@@ -3313,8 +3316,8 @@ void S9xRenderScreenHardware (bool8 sub)
 
 			// renderState.textureOffset = 1 interleaves main/sub into a 512->256 box downsample;
 			// at full 512px it instead samples into the next tile (black striping),
-			// so we disable it for hires.active too.
-			renderState.textureOffset = (!sub && !hiresMosaicActive && !GPU3DSExt.hires.active)
+			// so we disable it for render2x.active too.
+			renderState.textureOffset = (!sub && !hiresMosaicActive && !GPU3DSExt.render2x.active)
 				? SGPU_STATE_ENABLED
 				: SGPU_STATE_DISABLED;
 			DRAW_16COLOR_HIRES_BG_INLINE(0, 0, 5, 11);
@@ -3514,7 +3517,8 @@ inline void S9xUpdateColorMathSections()
 void S9xCommitClipToBlackAndColorMathSections() {
 	u32 batchStencilTest;
 	SGPU_ALPHA_BLENDINGMODE batchAlphaBlending;
-
+	int renderWidth = GPU3DSExt.renderWidth;
+	
 	for (int i = VS_CLIP_TO_BLACK; i <= VS_COLOR_MATH; i++) {
 		if (!drawableSectionCount[i])
 			continue;
@@ -3528,8 +3532,8 @@ void S9xCommitClipToBlackAndColorMathSections() {
 			
 			// hires/sub color math
 			if (renderState.textureEnv == TEX_ENV_REPLACE_TEXTURE0) {
-				gpu3dsAddTileVertexes(0, section->startY, 256, section->endY + 1,
-					0, section->startY, 256, section->endY + 1, 0);
+				gpu3dsAddTileVertexes(0, section->startY, renderWidth, section->endY + 1,
+					0, section->startY, renderWidth, section->endY + 1, 0);
 
 				renderState.textureBind = SNES_SUB;
 				renderState.stencilTest = section->value.v2;
@@ -3618,6 +3622,7 @@ void S9xCommitWindowLRSection(VerticalSections *verticalSections)
 	int stencilMask[10];
 
 	bool windowingEverEnabled = false;
+	int hiShift = GPU3DSExt.render2x.active ? 1 : 0;
 	
 	for (int i = 0; i < verticalSections->Count; i++)
 	{
@@ -3638,7 +3643,6 @@ void S9xCommitWindowLRSection(VerticalSections *verticalSections)
 
 		ComputeClipWindowsForStenciling (w1Left, w1Right, w2Left, w2Right, stencilEndX, stencilMask);
 
-		int hiShift = GPU3DSExt.hires.active ? 1 : 0;
 		int startX = 0;
 		for (int s = 0; s < 10; s++)
 		{
@@ -3791,10 +3795,18 @@ void S9xUpdateScreenHardware ()
 	
     GFX.Pseudo = (Memory.FillRAM [0x2133] & 8);
 
-	// Full 512px hi-res rendering, opt-in. Mode 5 only
-	// Mode 6 (hi-res + offset-per-tile) still uses the non-hi-res offset path and stays at 256.
-	GPU3DSExt.hires.active = GPU3DSExt.hires.enabled && (PPU.BGMode == 5);
-	GPU3DSExt.renderWidth = GPU3DSExt.hires.active ? 512 : 256;
+	// Enhanced Resolution: 
+	// a frame renders at 512px if any section uses Mode 5 or 7.
+	// Decided once per frame, constant across its sections.
+	if (GPU3DSExt.render2x.lastUpdateFrame != (int)ICPU.Frame) {
+		GPU3DSExt.render2x.lastUpdateFrame = (int)ICPU.Frame;
+		GPU3DSExt.render2x.active = GPU3DSExt.render2x.enabled && GPU3DSExt.render2x.has2xMode;
+		GPU3DSExt.render2x.has2xMode = false;
+	}
+	if (PPU.BGMode == 5 || PPU.BGMode == 7)
+		GPU3DSExt.render2x.has2xMode = true;
+
+	GPU3DSExt.renderWidth = GPU3DSExt.render2x.active ? 512 : 256;
 
 	GFX.StartY = IPPU.PreviousLine;
 	GFX.EndY = IPPU.CurrentLine - 1;

--- a/source/Snes9x/gfxhw.cpp
+++ b/source/Snes9x/gfxhw.cpp
@@ -317,7 +317,7 @@ void S9xCommitBackdropSections() {
 		{
 			DrawableVerticalSection *section = &drawableVerticalSections[i][j];
 
-			gpu3dsAddRectangleVertexes(0, section->startY + (int)section->value.v2, 256, section->endY + 1 + (int)section->value.v2, section->value.color);
+			gpu3dsAddRectangleVertexes(0, section->startY + (int)section->value.v2, GPU3DSExt.renderWidth, section->endY + 1 + (int)section->value.v2, section->value.color);
 		}
 
 		gpu3dsCommitLayerSection(VBO_SCENE_RECT, LAYER_BACKDROP, &renderState, sub);
@@ -887,15 +887,16 @@ inline void __attribute__((always_inline)) S9xDrawHiresBGFullTileHardwareInline 
         cache3dsCacheSnesTileToTexturePosition(pCache, screenColors, texturePos);
     }
 
-	int x0 = screenX >> 1;
+	bool fullWidth = GPU3DSExt.hires.active;
+	int x0 = fullWidth ? screenX : (screenX >> 1);
 	int y0 = screenY + (prio == 0 ? depth0 : depth1);
-	
-	int x1 = x0 + 4;
+
+	int x1 = x0 + (fullWidth ? 8 : 4);
 	int y1 = y0 + height;
 
 	int tx0 = 0;
 	int ty0 = startLine >> 3;
-	int tx1 = 7;
+	int tx1 = fullWidth ? 8 : 7;
 	int ty1 = stretchedTy ? (ty0 + 1) : (ty0 + height);
 
 	if (IPPU.Interlace && !stretchedTy)
@@ -2120,10 +2121,11 @@ void S9xDrawBackgroundMosaicHardware(
 
             int blockW = (X + outBlockW > 256) ? (256 - X) : outBlockW;
 
+            int hiShift = GPU3DSExt.hires.active ? 1 : 0;
             int yDepth = (tpriority == 0 ? depth0 : depth1);
-            int x0 = X;
+            int x0 = X << hiShift;
             int y0 = Y + yDepth;
-            int x1 = X + blockW;
+            int x1 = (X + blockW) << hiShift;
             int y1 = Y + blockH + yDepth;
 
             gpu3dsAddTileVertexes(
@@ -2572,12 +2574,15 @@ inline void __attribute__((always_inline)) S9xDrawOBJTileHardware2 (
 	// Remove the test for sub screen (fixed Mickey mouse transparency problem when Mickey's
 	// talking to the wizard)
 	//
-	if (pal < 4)					
+	if (pal < 4)
 		depth = depth & 0xfff;		// remove the alpha.
-	int x0 = screenX;
+
+	// at full 512px, texels are stretched 1->2px via nearest
+	int hiShift = GPU3DSExt.hires.active ? 1 : 0;
+	int x0 = screenX << hiShift;
 	int y0 = screenY + depth;
-		
-	int x1 = x0 + 8;
+
+	int x1 = x0 + (8 << hiShift);
 	int y1 = y0 + height;
 
 	int tx0 = 0;
@@ -3304,10 +3309,12 @@ void S9xRenderScreenHardware (bool8 sub)
             break;
         case 5:
 		{
-			// Keeping the +1 main-screen texture offset would introduce 
-			// horizontal subpixel artifacts in hires mosaic blocks
 			bool hiresMosaicActive = MOSAIC_GATE_HIRES(0) || MOSAIC_GATE_HIRES(1);
-			renderState.textureOffset = (!sub && !hiresMosaicActive)
+
+			// renderState.textureOffset = 1 interleaves main/sub into a 512->256 box downsample;
+			// at full 512px it instead samples into the next tile (black striping),
+			// so we disable it for hires.active too.
+			renderState.textureOffset = (!sub && !hiresMosaicActive && !GPU3DSExt.hires.active)
 				? SGPU_STATE_ENABLED
 				: SGPU_STATE_DISABLED;
 			DRAW_16COLOR_HIRES_BG_INLINE(0, 0, 5, 11);
@@ -3550,7 +3557,7 @@ void S9xCommitClipToBlackAndColorMathSections() {
 					batchAlphaBlending = (SGPU_ALPHA_BLENDINGMODE)section->state.alphaBlending;
 				}
 			
-				gpu3dsAddRectangleVertexes(0, section->startY, 256, section->endY + 1, section->value.color);
+				gpu3dsAddRectangleVertexes(0, section->startY, GPU3DSExt.renderWidth, section->endY + 1, section->value.color);
 
 				// commit last batch
 				bool isLastBatch = j >= drawableSectionCount[i] - 1
@@ -3589,7 +3596,7 @@ void S9xCommitBrightnessSection(VerticalSections *verticalSections)
 
 		gpu3dsAddRectangleVertexes(
 			0, verticalSections->Section[i].StartY,
-			256, verticalSections->Section[i].EndY + 1, alpha);
+			GPU3DSExt.renderWidth, verticalSections->Section[i].EndY + 1, alpha);
 		hasVertexes = true;
 	}
 
@@ -3631,13 +3638,14 @@ void S9xCommitWindowLRSection(VerticalSections *verticalSections)
 
 		ComputeClipWindowsForStenciling (w1Left, w1Right, w2Left, w2Right, stencilEndX, stencilMask);
 
+		int hiShift = GPU3DSExt.hires.active ? 1 : 0;
 		int startX = 0;
 		for (int s = 0; s < 10; s++)
 		{
 			int endX = stencilEndX[s];
 			int mask = stencilMask[s];
-			gpu3dsAddRectangleVertexes(startX, startY, endX, endY + 1, (mask << 29));	
-			
+			gpu3dsAddRectangleVertexes(startX << hiShift, startY, endX << hiShift, endY + 1, (mask << 29));
+
 			startX = endX;
 			if (startX >= 256)
 				break;
@@ -3782,6 +3790,11 @@ void S9xUpdateScreenHardware ()
     GFX.r2130 = Memory.FillRAM [0x2130];
 	
     GFX.Pseudo = (Memory.FillRAM [0x2133] & 8);
+
+	// Full 512px hi-res rendering, opt-in. Mode 5 only
+	// Mode 6 (hi-res + offset-per-tile) still uses the non-hi-res offset path and stays at 256.
+	GPU3DSExt.hires.active = GPU3DSExt.hires.enabled && (PPU.BGMode == 5);
+	GPU3DSExt.renderWidth = GPU3DSExt.hires.active ? 512 : 256;
 
 	GFX.StartY = IPPU.PreviousLine;
 	GFX.EndY = IPPU.CurrentLine - 1;

--- a/source/Snes9x/gfxhw.cpp
+++ b/source/Snes9x/gfxhw.cpp
@@ -780,7 +780,7 @@ inline void __attribute__((always_inline)) S9xDrawBGFullTileHardwareInline (
 
 	// Render tile
 	//
-	int hiShift = GPU3DSExt.render2x.active ? 1 : 0;
+	int hiShift = GPU3DSExt.render2x.enabled ? 1 : 0;
 	int x0 = screenX << hiShift;
 	int y0 = screenY + (prio == 0 ? depth0 : depth1);
 	int x1 = x0 + (8 << hiShift);
@@ -888,7 +888,7 @@ inline void __attribute__((always_inline)) S9xDrawHiresBGFullTileHardwareInline 
         cache3dsCacheSnesTileToTexturePosition(pCache, screenColors, texturePos);
     }
 
-	bool fullWidth = GPU3DSExt.render2x.active;
+	bool fullWidth = GPU3DSExt.render2x.enabled;
 	int x0 = fullWidth ? screenX : (screenX >> 1);
 	int y0 = screenY + (prio == 0 ? depth0 : depth1);
 
@@ -1995,7 +1995,7 @@ void S9xDrawBackgroundMosaicHardware(
     int YEnd   = (int)GFX.EndY + 1;
     int MosaicOffset = YStart % S;
     int FirstBlockH = S - MosaicOffset;
-	int hiShift = GPU3DSExt.render2x.active ? 1 : 0;
+	int hiShift = GPU3DSExt.render2x.enabled ? 1 : 0;
 
     for (int Y = YStart; Y < YEnd; )
     {
@@ -2579,7 +2579,7 @@ inline void __attribute__((always_inline)) S9xDrawOBJTileHardware2 (
 		depth = depth & 0xfff;		// remove the alpha.
 
 	// at full 512px, texels are stretched 1->2px via nearest
-	int hiShift = GPU3DSExt.render2x.active ? 1 : 0;
+	int hiShift = GPU3DSExt.render2x.enabled ? 1 : 0;
 	int x0 = screenX << hiShift;
 	int y0 = screenY + depth;
 
@@ -3079,7 +3079,7 @@ void S9xDrawBackgroundMode7Hardware(int bg, bool8 sub, int depth, int alphaTestA
 	else
 		alphaTest = GFX.r2131 & 0x40 ? ALPHA_TEST_GTE_0_5 : ALPHA_TEST_GTE_1_0;
 	
-	int hiShift = GPU3DSExt.render2x.active ? 1 : 0;
+	int hiShift = GPU3DSExt.render2x.enabled ? 1 : 0;
 
 	for (int Y = (int)LayerRender.startY[bg]; Y <= (int)GFX.EndY; Y++)
 	{
@@ -3142,7 +3142,7 @@ void S9xDrawBackgroundMode7Hardware(int bg, bool8 sub, int depth, int alphaTestA
 void S9xDrawBackgroundMode7HardwareRepeatTile0(int bg, bool8 sub, int depth)
 {
 	bool verticesUpdated = false;
-	int hiShift = GPU3DSExt.render2x.active ? 1 : 0;
+	int hiShift = GPU3DSExt.render2x.enabled ? 1 : 0;
 	
 	for (int Y = (int)LayerRender.startY[bg]; Y <= (int)GFX.EndY; Y++)
 	{
@@ -3316,8 +3316,8 @@ void S9xRenderScreenHardware (bool8 sub)
 
 			// renderState.textureOffset = 1 interleaves main/sub into a 512->256 box downsample;
 			// at full 512px it instead samples into the next tile (black striping),
-			// so we disable it for render2x.active too.
-			renderState.textureOffset = (!sub && !hiresMosaicActive && !GPU3DSExt.render2x.active)
+			// so we disable it for render2x.enabled too.
+			renderState.textureOffset = (!sub && !hiresMosaicActive && !GPU3DSExt.render2x.enabled)
 				? SGPU_STATE_ENABLED
 				: SGPU_STATE_DISABLED;
 			DRAW_16COLOR_HIRES_BG_INLINE(0, 0, 5, 11);
@@ -3622,7 +3622,7 @@ void S9xCommitWindowLRSection(VerticalSections *verticalSections)
 	int stencilMask[10];
 
 	bool windowingEverEnabled = false;
-	int hiShift = GPU3DSExt.render2x.active ? 1 : 0;
+	int hiShift = GPU3DSExt.render2x.enabled ? 1 : 0;
 	
 	for (int i = 0; i < verticalSections->Count; i++)
 	{
@@ -3795,18 +3795,7 @@ void S9xUpdateScreenHardware ()
 	
     GFX.Pseudo = (Memory.FillRAM [0x2133] & 8);
 
-	// Enhanced Resolution: 
-	// a frame renders at 512px if any section uses Mode 5 or 7.
-	// Decided once per frame, constant across its sections.
-	if (GPU3DSExt.render2x.lastUpdateFrame != (int)ICPU.Frame) {
-		GPU3DSExt.render2x.lastUpdateFrame = (int)ICPU.Frame;
-		GPU3DSExt.render2x.active = GPU3DSExt.render2x.enabled && GPU3DSExt.render2x.has2xMode;
-		GPU3DSExt.render2x.has2xMode = false;
-	}
-	if (PPU.BGMode == 5 || PPU.BGMode == 7)
-		GPU3DSExt.render2x.has2xMode = true;
-
-	GPU3DSExt.renderWidth = GPU3DSExt.render2x.active ? 512 : 256;
+	GPU3DSExt.renderWidth = GPU3DSExt.render2x.enabled ? 512 : 256;
 
 	GFX.StartY = IPPU.PreviousLine;
 	GFX.EndY = IPPU.CurrentLine - 1;


### PR DESCRIPTION

Add Enhanced Resolution as a three-mode setting: Off, Standard, and 2x Screen

- 2x Screen option only for wide-capable devices + game screen = top screen
- Mode 5 uses true SNES hi-res rendering
- Mode 7 benefits from finer sampling
- other layers are rendered at 2x width (double pixels)